### PR TITLE
Sprint 3 — Export & Lightweight Insights

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,5 @@ SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
 SUPABASE_ANON_KEY=ey...PUBLIC_ANON_KEY...
 # Never expose this in client code. Server uses it to proxy requests.
 SUPABASE_SERVICE_ROLE_KEY=ey...SERVICE_ROLE_SECRET...
-\n+# Optional: increases GitHub API rate limits and avoids 403 on burst.
 # Create a classic token with read:org (or no extra scopes) if needed.
 GITHUB_TOKEN=

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -33,6 +33,16 @@ The Supabase Explorer provides a compact way to browse tables and see how rows r
   - Heuristics need `*_id` to match a table name (`user_id` → `users`).
 - To get exact relationships, install the `public.db_relations` RPC described in `docs/RELATIONS.md` (no UI change required).
 
+## Export & Print
+
+- Export CSV — downloads the current grid slice using the visible columns (primary `id` excluded). Values are safely quoted for Excel/Numbers.
+- Export JSON — downloads `{ columns, rows, meta }` where `meta` includes `table`, `limit`, `offset`, and `total` if known.
+- Print — use the browser’s print dialog; the UI includes a print stylesheet that hides navigation chrome and lays out content as a clean, single-column document with sensible page breaks.
+
+Notes
+- Exports operate purely on the client using already-fetched rows; no extra server work.
+- Filenames include the table name and range for traceability, e.g., `users_001-050.csv`.
+
 ## Notes on Expanders
 
 - Expanding a row makes two API calls (`/api/sb/outbound` and `/api/sb/inbound`) for that row ID.

--- a/public/index.html
+++ b/public/index.html
@@ -8,17 +8,24 @@
   </head>
   <body>
     <main class="layout">
-      <aside class="sidebar">
-        <h2>Tables</h2>
-        <input id="tableSearch" class="input" placeholder="Filter tables..." />
-        <ul id="tableList" class="table-list"></ul>
-      </aside>
+	      <aside class="sidebar">
+	        <h2>Tables</h2>
+	        <input id="tableSearch" class="input" placeholder="Filter tables..." />
+	        <ul id="tableList" class="table-list"></ul>
+
+	        <h2>Saved Views</h2>
+	        <div class="views-bar">
+	          <button id="saveViewBtn" aria-label="Save current view">Save View</button>
+	        </div>
+	        <ul id="viewList" class="table-list"></ul>
+	      </aside>
 
       <section class="content">
         <header class="content-header">
           <div>
             <h1 id="tableTitle">Data Explorer</h1>
             <div id="tableSubtitle" class="muted">Select a table to begin</div>
+            <div id="filterChips" class="chips"></div>
           </div>
           <div class="toolbar">
             <label>Page size
@@ -26,15 +33,24 @@
                 <option>25</option>
                 <option selected>50</option>
                 <option>100</option>
+                <option>1000</option>
+                <option>5000</option>
               </select>
             </label>
+            <button id="themeToggle" aria-label="Toggle theme">Theme</button>
             <button id="prevPage">Prev</button>
-            <button id="nextPage">Next</button>
+	            <button id="nextPage">Next</button>
+	            <button id="applyFirstViewBtn" aria-label="Apply saved view">Apply View</button>
+	            <span class="spacer"></span>
+            <button id="exportCsv" title="Download visible rows as CSV">Export CSV</button>
+            <button id="exportJson" title="Download visible rows as JSON">Export JSON</button>
           </div>
         </header>
 
+        <div id="summaryBar" class="summary" aria-live="polite"></div>
+
         <div class="table-container">
-          <table class="table" id="sbGrid"></table>
+          <table class="table" id="sbGrid" role="grid" aria-label="Data grid" tabindex="0"></table>
         </div>
       </section>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,9 +1,49 @@
 :root {
-  color-scheme: light dark;
+  color-scheme: dark light;
+  /* Palette */
   --bg: #0b0c0f;
   --fg: #e6e8ea;
   --accent: #7cd7ff;
   --muted: #9aa4af;
+  --border: #1b1f2a;
+  --panel: #0d1218;
+  --focus: #82b1ff;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+
+  /* Type scale */
+  --fs-xs: 0.75rem;
+  --fs-sm: 0.875rem;
+  --fs-md: 0.95rem;
+  --fs-lg: 1.2rem;
+  --fs-xl: 1.6rem;
+
+  /* Radii + z-index */
+  --radius-2: 6px;
+  --radius-3: 8px;
+  --z-header: 1;
+  --z-overlay: 1000;
+
+  /* Grid */
+  --row-h: 32px;
+}
+
+/* Light theme overrides */
+[data-theme="light"] {
+  color-scheme: light dark;
+  --bg: #f7f8fa;
+  --fg: #0f1720;
+  --muted: #5b6673;
+  --border: #d6d9df;
+  --panel: #ffffff;
+  --accent: #0b6bcb;
+  --focus: #0b6bcb;
 }
 
 * { box-sizing: border-box; }
@@ -14,34 +54,37 @@ body {
   background: var(--bg);
   color: var(--fg);
 }
-main { max-width: 1200px; margin: 1.5rem auto; padding: 0 1rem; }
-h1 { font-size: 1.6rem; margin: 0 0 1rem; }
-h2 { font-size: 1.2rem; margin: 2rem 0 0.5rem; }
-section { padding: 1rem; border: 1px solid #222; border-radius: 8px; }
+main { max-width: 1200px; margin: var(--space-5) auto; padding: 0 var(--space-4); }
+h1 { font-size: var(--fs-xl); margin: 0 0 var(--space-3); }
+h2 { font-size: var(--fs-lg); margin: var(--space-5) 0 var(--space-2); }
+section { padding: var(--space-4); border: 1px solid var(--border); border-radius: var(--radius-3); background: var(--panel); }
 button {
   background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer;
   padding: 0.5rem 0.75rem; font-weight: 600; letter-spacing: 0.2px;
 }
 button:hover { filter: brightness(1.05); }
+button:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
 pre {
-  background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
+  background: #0f1115; border: 1px solid var(--border); padding: var(--space-3); border-radius: var(--radius-2);
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
-textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
+textarea { width: 100%; padding: var(--space-2); border-radius: var(--radius-2); border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
 .muted { color: var(--muted); }
-.table-container { overflow-y: auto; overflow-x: hidden; max-height: 560px; border: 1px solid #1b1f2a; border-radius: 6px; margin-top: 0.5rem; }
-.table { width: 100%; border-collapse: collapse; font-size: 0.9rem; table-layout: fixed; }
-.table th, .table td { border-bottom: 1px solid #1b1f2a; padding: 0.4rem 0.6rem; vertical-align: top; max-width: 280px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.table th { background: #0d1218; position: sticky; top: 0; z-index: 1; text-align: left; }
+.table-container { overflow-y: auto; overflow-x: hidden; max-height: 560px; border: 1px solid var(--border); border-radius: var(--radius-2); margin-top: var(--space-2); }
+.table { width: 100%; border-collapse: collapse; font-size: var(--fs-md); table-layout: fixed; }
+.table th, .table td { border-bottom: 1px solid var(--border); padding: 0.4rem 0.6rem; vertical-align: top; max-width: 280px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.table th { background: var(--panel); position: sticky; top: 0; z-index: var(--z-header); text-align: left; }
 .tag { display: inline-block; padding: 0.15rem 0.35rem; border: 1px solid #333; border-radius: 999px; font-size: 0.75rem; }
 .link { color: var(--accent); cursor: pointer; }
-.row-click { cursor: pointer; }
+.row-click { cursor: pointer; height: var(--row-h); }
+.row-click.selected td { background: rgba(124, 215, 255, 0.12); }
+.row-click:focus-visible td { outline: 2px solid var(--focus); outline-offset: -2px; }
 .expander-cell { width: 24px; text-align: center; }
 .expand-toggle { cursor: pointer; background: transparent; color: var(--muted); border: 1px solid #333; border-radius: 4px; width: 22px; height: 22px; line-height: 18px; font-size: 12px; padding: 0; }
 .expand-toggle:hover { filter: brightness(1.1); }
-.expand-row td { background: #0d1118; padding: 0.6rem; }
+.expand-row td { background: var(--panel); padding: 0.6rem; }
 .expand-wrap { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
 
 /* Inline object + chips */
@@ -59,24 +102,64 @@ label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 }
 
 /* Dashboard layout */
-.layout { display: grid; grid-template-columns: 240px minmax(0, 1fr) 360px; gap: 1rem; }
-.sidebar { border: 1px solid #222; border-radius: 8px; padding: 1rem; height: fit-content; position: sticky; top: 1rem; align-self: start; }
-.content { border: 1px solid #222; border-radius: 8px; padding: 1rem; min-width: 0; }
-.inspector { border: 1px solid #222; border-radius: 8px; padding: 1rem; height: fit-content; position: sticky; top: 1rem; align-self: start; min-width: 0; }
+.layout { display: grid; grid-template-columns: 240px minmax(0, 1fr) 360px; gap: var(--space-4); }
+.sidebar { border: 1px solid var(--border); border-radius: var(--radius-3); padding: var(--space-4); height: fit-content; position: sticky; top: var(--space-4); align-self: start; background: var(--panel); }
+.content { border: 1px solid var(--border); border-radius: var(--radius-3); padding: var(--space-4); min-width: 0; background: var(--panel); }
+.inspector { border: 1px solid var(--border); border-radius: var(--radius-3); padding: var(--space-4); height: fit-content; position: sticky; top: var(--space-4); align-self: start; min-width: 0; background: var(--panel); }
 .content-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 1rem; }
 .toolbar { display: flex; gap: 0.5rem; align-items: center; }
+.toolbar .spacer { flex: 1 1 auto; }
 .toolbar select { padding: 0.35rem 0.5rem; border-radius: 6px; background: transparent; color: inherit; border: 1px solid #333; }
 .input { width: 100%; padding: 0.4rem 0.5rem; border: 1px solid #333; border-radius: 6px; background: transparent; color: inherit; }
 .table-list { list-style: none; padding: 0; margin: 0.5rem 0 0; max-height: 520px; overflow: auto; }
 .table-list li { padding: 0.35rem 0.5rem; border-radius: 6px; cursor: pointer; }
-.table-list li:hover { background: #0d1218; }
+.table-list li:hover { background: var(--panel); filter: brightness(1.05); }
 .table-list li.active { background: #132132; color: #fff; }
-.card { border: 1px solid #1b1f2a; border-radius: 8px; padding: 0.75rem; margin-top: 0.75rem; max-width: 100%; overflow: hidden; }
+.views-bar { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.5rem; }
+.chips { display: flex; gap: 0.35rem; flex-wrap: wrap; margin-top: 0.25rem; }
+.card { border: 1px solid var(--border); border-radius: var(--radius-3); padding: var(--space-3); margin-top: var(--space-3); max-width: 100%; overflow: hidden; background: var(--panel); }
 .kv { display: grid; grid-template-columns: 1fr 2fr; gap: 0.25rem 0.75rem; font-size: 0.9rem; }
 .kv div.key { color: var(--muted); }
 .kv .value { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .inspector { overflow-x: hidden; }
 .rel-sections { display: grid; gap: 0.75rem; }
 .mini-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; table-layout: fixed; }
-.mini-table th, .mini-table td { border-bottom: 1px solid #1b1f2a; padding: 0.25rem 0.3rem; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mini-table th, .mini-table td { border-bottom: 1px solid var(--border); padding: 0.25rem 0.3rem; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .details { margin-top: 1rem; }
+
+/* Skeleton loader */
+.skeleton { position: relative; overflow: hidden; background: #11151b; }
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent);
+  transform: translateX(-100%);
+  animation: shimmer 1.2s infinite;
+}
+@keyframes shimmer { to { transform: translateX(100%); } }
+
+/* Virtualization spacer rows */
+.v-spacer td { padding: 0; border: none; height: 0; }
+
+/* Summary (optional lightweight insights) */
+.summary { margin: 0.5rem 0 0; font-size: 0.9rem; color: var(--muted); }
+.summary .bars { display: grid; grid-auto-flow: row; gap: 4px; margin-top: 4px; }
+.summary .bar { display: grid; grid-template-columns: auto 1fr auto; gap: 6px; align-items: center; }
+.summary .bar .track { background: #0d1218; border: 1px solid #1b1f2a; height: 10px; border-radius: 999px; overflow: hidden; }
+.summary .bar .fill { background: #1a73e8; height: 100%; }
+
+/* Print styles */
+@media print {
+  :root { color-scheme: light; }
+  body { background: #fff; color: #111; }
+  main { max-width: none; margin: 0; padding: 0; }
+  .layout { display: block; }
+  .sidebar, .toolbar, #diagnostics { display: none !important; }
+  .content, .inspector { border: none; padding: 0.5in 0.6in; }
+  .content-header { margin-bottom: 0.2in; }
+  .table-container { max-height: none; border: none; }
+  .table th { background: transparent; color: #111; }
+  .card { break-inside: avoid; page-break-inside: avoid; border-color: #ccc; }
+  .mini-table th, .mini-table td, .table th, .table td { border-color: #ccc; color: #111; }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -36,7 +36,7 @@
 
 /* Light theme overrides */
 [data-theme="light"] {
-  color-scheme: light dark;
+  color-scheme: light;
   --bg: #f7f8fa;
   --fg: #0f1720;
   --muted: #5b6673;

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -41,7 +41,10 @@ window.addEventListener('DOMContentLoaded', () => {
     pageSizeSel: byId<HTMLSelectElement>('pageSize'),
     prevPageBtn: byId<HTMLButtonElement>('prevPage'),
     nextPageBtn: byId<HTMLButtonElement>('nextPage'),
+    exportCsvBtn: byId<HTMLButtonElement>('exportCsv'),
+    exportJsonBtn: byId<HTMLButtonElement>('exportJson'),
     grid: byId<HTMLTableElement>('sbGrid'),
+    summaryEl: byId<HTMLDivElement>('summaryBar'),
     inspectorTitle: byId<HTMLHeadingElement>('inspectorTitle'),
     objectSummary: byId<HTMLDivElement>('objectSummary'),
     relatedOutbound: byId<HTMLDivElement>('relatedOutbound'),
@@ -90,7 +93,10 @@ type DashboardOpts = {
   pageSizeSel: HTMLSelectElement;
   prevPageBtn: HTMLButtonElement;
   nextPageBtn: HTMLButtonElement;
+  exportCsvBtn: HTMLButtonElement;
+  exportJsonBtn: HTMLButtonElement;
   grid: HTMLTableElement;
+  summaryEl: HTMLDivElement;
   inspectorTitle: HTMLHeadingElement;
   objectSummary: HTMLDivElement;
   relatedOutbound: HTMLDivElement;
@@ -207,6 +213,8 @@ function createDashboard(opts: DashboardOpts) {
         state.table,
         state.relationsByColumn,
       );
+      // Update lightweight summary/insights
+      renderSummary(opts.summaryEl, state.table, cols, rows);
       const rn = rows.length;
       const range = rn > 0 ? `${state.offset + 1}–${state.offset + rn}` : '0';
       const total = state.total != null ? ` of ${state.total}` : '';
@@ -253,6 +261,29 @@ function createDashboard(opts: DashboardOpts) {
     void loadPage(true);
   });
   opts.tableSearch.addEventListener('input', renderTableList);
+
+  // Wire exports (CSV/JSON) from current in-memory slice
+  opts.exportCsvBtn.addEventListener('click', () => {
+    const cols = state.lastCols.filter((c) => c !== 'id');
+    const csv = toCSV(cols, state.lastRows);
+    const range = state.lastRows.length
+      ? `${String(state.offset + 1).padStart(3, '0')}-${String(state.offset + state.lastRows.length).padStart(3, '0')}`
+      : 'empty';
+    const fname = sanitizeFilename(`${state.table || 'data'}_${range}.csv`);
+    downloadText(fname, 'text/csv', csv);
+  });
+  opts.exportJsonBtn.addEventListener('click', () => {
+    const payload = {
+      columns: state.lastCols.filter((c) => c !== 'id'),
+      rows: state.lastRows,
+      meta: { table: state.table, limit: state.limit, offset: state.offset, total: state.total },
+    };
+    const range = state.lastRows.length
+      ? `${String(state.offset + 1).padStart(3, '0')}-${String(state.offset + state.lastRows.length).padStart(3, '0')}`
+      : 'empty';
+    const fname = sanitizeFilename(`${state.table || 'data'}_${range}.json`);
+    downloadText(fname, 'application/json', JSON.stringify(payload, null, 2));
+  });
 
   void init();
 
@@ -330,6 +361,91 @@ function createDashboard(opts: DashboardOpts) {
       opts.relatedInbound.textContent = `Failed: ${inbound.status}`;
     }
   }
+}
+
+// --- Export helpers & lightweight insights ---
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, '_');
+}
+
+function toCSV(cols: string[], rows: Record<string, unknown>[]): string {
+  const esc = (v: unknown): string => {
+    let s: string;
+    if (v == null) s = '';
+    else if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') s = String(v);
+    else s = safeJSONStringify(v);
+    if (/[",\n]/.test(s)) s = '"' + s.replace(/"/g, '""') + '"';
+    return s;
+  };
+  const header = cols.join(',');
+  const body = rows.map((r) => cols.map((c) => esc((r as Record<string, unknown>)[c])).join(',')).join('\n');
+  return body ? header + '\n' + body : header + '\n';
+}
+
+function downloadText(filename: string, mime: string, text: string): void {
+  const blob = new Blob([text], { type: mime + ';charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function safeJSONStringify(v: unknown): string {
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+function renderSummary(
+  container: HTMLElement,
+  table: string,
+  cols: string[],
+  rows: Record<string, unknown>[],
+) {
+  if (!container) return;
+  if (!rows || rows.length === 0) {
+    container.textContent = '';
+    return;
+  }
+  // Choose a categorical column to summarize
+  const preferred = ['node_type', 'status', 'type'];
+  let col = preferred.find((c) => cols.includes(c)) ?? '';
+  if (!col) {
+    for (const c of cols) {
+      if (c.endsWith('_id')) continue;
+      const vals = rows.map((r) => r[c]).filter((v) => v != null);
+      const strVals = vals.map((v) => String(v));
+      const uniq = new Set(strVals);
+      if (uniq.size > 1 && uniq.size <= 10) {
+        col = c;
+        break;
+      }
+    }
+  }
+  const total = rows.length;
+  let html = `<span class="muted">${table || 'Rows'}: ${total}</span>`;
+  if (col) {
+    const counts = new Map<string, number>();
+    for (const r of rows) {
+      const k = String(r[col] ?? '');
+      counts.set(k, (counts.get(k) ?? 0) + 1);
+    }
+    const max = Math.max(1, ...counts.values());
+    html += '<div class="bars">';
+    for (const [k, n] of counts.entries()) {
+      const pct = Math.round((n / max) * 100);
+      html += `<div class="bar"><span>${k || '(none)'}</span><span class="track"><span class="fill" style="width:${pct}%"></span></span><span>${n}</span></div>`;
+    }
+    html += '</div>';
+  }
+  container.innerHTML = html;
 }
 
 function deriveColumns(rows: Record<string, unknown>[]): string[] {


### PR DESCRIPTION
Implements Sprint 3: client-side export and lightweight insights.

Changes
- Export CSV/JSON from current grid slice (ID columns excluded).
- Print stylesheet for clean single-column print/PDF.
- Optional summary bar with quick category totals from visible rows.
- Docs updated for export/print usage.

Resolves #https://github.com/0x4007/os.ubq.fi/issues/18