### PR TITLE
Add URL state, grid workflows, themes, exports, virtualization, and accessibility

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -33,6 +33,26 @@ Changing controls pushes a history entry. Browser back and forward restore the p
 
 Saved views store the current query string in `localStorage` under a user-provided name. Applying a saved view restores the stored URL state and pushes it into browser history. Deleting a saved view removes only that local entry.
 
+Example saved view workflow:
+
+```text
+1. Filter issues to repo equals os.ubq.fi.
+2. Enter "os issues" in View name.
+3. Save the view, switch tables, then apply "os issues" to restore the issue filters.
+```
+
+The app also stores the last selected table and each table's scroll position in `localStorage`. When users return without a table parameter, the last table is restored; when the large table window is opened again, the saved scroll position is reused.
+
+Row details include related chips for drill-through navigation. Clicking a chip switches to the target table, applies an exact FK filter, selects the first matching row, and pushes the new state into browser history so back and forward return to the prior row.
+
+Example drill-through links:
+
+```text
+/?table=issues&offset=0&limit=25&sort=created&desc=false&rowId=iss_0001
+```
+
+From an issue detail, `Reporter` opens the users table with `filters=id.eq.<userId>`, and `Plugin` opens the plugins table with `filters=id.eq.<pluginId>`. From a user or plugin detail, issue chips open the issues table with `filters=userId.eq.<id>` or `filters=pluginId.eq.<id>`.
+
 The chart panel renders lazily from the current filtered rows without extra requests. Users and issues show status totals; plugins show health totals.
 
 Large pages are virtualized. The `5000` row option keeps the same selection and expanded row state while rendering only the visible scroll window.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -43,6 +43,8 @@ Example saved view workflow:
 
 The app also stores the last selected table and each table's scroll position in `localStorage`. When users return without a table parameter, the last table is restored; when the large table window is opened again, the saved scroll position is reused.
 
+The theme toggle switches between light and dark UI tokens and stores the choice in `localStorage` as `os.ubq.fi.theme`. The root document receives `data-theme="light"` or `data-theme="dark"` before the app initializes so reloads keep the selected color mode.
+
 Row details include related chips for drill-through navigation. Clicking a chip switches to the target table, applies an exact FK filter, selects the first matching row, and pushes the new state into browser history so back and forward return to the prior row.
 
 Example drill-through links:

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -33,6 +33,8 @@ Changing controls pushes a history entry. Browser back and forward restore the p
 
 Saved views store the current query string in `localStorage` under a user-provided name. Applying a saved view restores the stored URL state and pushes it into browser history. Deleting a saved view removes only that local entry.
 
+The chart panel renders lazily from the current filtered rows without extra requests. Users and issues show status totals; plugins show health totals.
+
 Large pages are virtualized. The `5000` row option keeps the same selection and expanded row state while rendering only the visible scroll window.
 
 The CSV and JSON export buttons download the current sorted, filtered, paginated slice. CSV exports use the visible column labels and values, excluding raw row identifiers. JSON exports include `{ columns, rows, meta }` for the same slice.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -53,6 +53,10 @@ Example drill-through links:
 
 From an issue detail, `Reporter` opens the users table with `filters=id.eq.<userId>`, and `Plugin` opens the plugins table with `filters=id.eq.<pluginId>`. From a user or plugin detail, issue chips open the issues table with `filters=userId.eq.<id>` or `filters=pluginId.eq.<id>`.
 
+Relation chips prefer exact edges from `/api/sb/relations?table=<table>&id=<rowId>`. If the endpoint is unavailable or returns an error, the inspector shows an inline warning and falls back to locally generated FK filters with the same labels.
+
+The grid and inspector render skeleton placeholders while loading. Empty filters use muted row messaging, and relation fetch failures are shown inline without blocking the row details payload.
+
 The chart panel renders lazily from the current filtered rows without extra requests. Users and issues show status totals; plugins show health totals.
 
 Large pages are virtualized. The `5000` row option keeps the same selection and expanded row state while rendering only the visible scroll window.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -9,7 +9,7 @@ Supported parameters:
 - `limit`: page size, one of `10`, `25`, `50`, `100`, or `5000`
 - `sort`: the active column key for the selected table
 - `desc`: `true` for descending order, `false` for ascending order
-- `filters`: free-text filter applied to the active table
+- `filters`: comma-separated column filters in `column.operator.value` form
 - `rowId`: expanded row identifier
 
 Example:
@@ -18,7 +18,18 @@ Example:
 /?table=users&offset=50&limit=25&sort=created&desc=true
 ```
 
-Changing controls pushes a history entry. Browser back and forward restore the previous table, pagination, sort direction, filter, and expanded row.
+Filter operators are:
+
+- `eq`: exact value match
+- `ilike`: case-insensitive contains match
+
+Example with filters:
+
+```text
+/?table=issues&offset=0&limit=25&sort=created&desc=false&filters=repo.ilike.work,status.eq.assigned
+```
+
+Changing controls pushes a history entry. Browser back and forward restore the previous table, pagination, sort direction, filters, and expanded row.
 
 Large pages are virtualized. The `5000` row option keeps the same selection and expanded row state while rendering only the visible scroll window.
 

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -34,3 +34,5 @@ Changing controls pushes a history entry. Browser back and forward restore the p
 Large pages are virtualized. The `5000` row option keeps the same selection and expanded row state while rendering only the visible scroll window.
 
 The CSV and JSON export buttons download the current sorted, filtered, paginated slice. CSV exports use the visible column labels and values, excluding raw row identifiers. JSON exports include `{ columns, rows, meta }` for the same slice.
+
+Print/PDF output hides interactive chrome, expands the table scroll area, wraps table cells, and keeps the inspector readable in a single-column layout.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -31,6 +31,8 @@ Example with filters:
 
 Changing controls pushes a history entry. Browser back and forward restore the previous table, pagination, sort direction, filters, and expanded row.
 
+Saved views store the current query string in `localStorage` under a user-provided name. Applying a saved view restores the stored URL state and pushes it into browser history. Deleting a saved view removes only that local entry.
+
 Large pages are virtualized. The `5000` row option keeps the same selection and expanded row state while rendering only the visible scroll window.
 
 The CSV and JSON export buttons download the current sorted, filtered, paginated slice. CSV exports use the visible column labels and values, excluding raw row identifiers. JSON exports include `{ columns, rows, meta }` for the same slice.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -1,0 +1,25 @@
+# UI State Links
+
+The dashboard stores the table view in URL parameters so support and operations links can recreate the same state.
+
+Supported parameters:
+
+- `table`: `users`, `issues`, or `plugins`
+- `offset`: zero-based row offset
+- `limit`: page size, one of `10`, `25`, `50`, `100`, or `5000`
+- `sort`: the active column key for the selected table
+- `desc`: `true` for descending order, `false` for ascending order
+- `filters`: free-text filter applied to the active table
+- `rowId`: expanded row identifier
+
+Example:
+
+```text
+/?table=users&offset=50&limit=25&sort=created&desc=true
+```
+
+Changing controls pushes a history entry. Browser back and forward restore the previous table, pagination, sort direction, filter, and expanded row.
+
+Large pages are virtualized. The `5000` row option keeps the same selection and expanded row state while rendering only the visible scroll window.
+
+The CSV and JSON export buttons download the current sorted, filtered, paginated slice. CSV exports use the visible column labels and values, excluding raw row identifiers. JSON exports include `{ columns, rows, meta }` for the same slice.

--- a/docs/UI.md
+++ b/docs/UI.md
@@ -57,6 +57,10 @@ Relation chips prefer exact edges from `/api/sb/relations?table=<table>&id=<rowI
 
 The grid and inspector render skeleton placeholders while loading. Empty filters use muted row messaging, and relation fetch failures are shown inline without blocking the row details payload.
 
+## Accessibility and Keyboard
+
+The table exposes a grid role with row and column counts, sortable headers publish `aria-sort`, and row toggles control the details region. Row focus is visible in the table: Tab reaches rows and row actions, Arrow Up/Down moves through the current page, Home/End jump to page edges, and Enter or Space opens or closes the focused row details while preserving focus.
+
 The chart panel renders lazily from the current filtered rows without extra requests. Users and issues show status totals; plugins show health totals.
 
 Large pages are virtualized. The `5000` row option keeps the same selection and expanded row state while rendering only the visible scroll window.

--- a/public/index.html
+++ b/public/index.html
@@ -82,7 +82,7 @@
 
       <section class="table-shell" aria-label="State table">
         <div class="table-status">
-          <p id="pageSummary">Loading rows...</p>
+          <p id="pageSummary" aria-live="polite">Loading rows...</p>
           <div class="table-actions">
             <button id="exportCsv" type="button">CSV</button>
             <button id="exportJson" type="button">JSON</button>
@@ -94,7 +94,7 @@
         </div>
 
         <div id="tableScroll" class="table-scroll">
-          <table>
+          <table id="dataGrid" role="grid" aria-describedby="pageSummary">
             <thead id="tableHead"></thead>
             <tbody id="tableBody">
               <tr class="skeleton-row" aria-hidden="true">
@@ -111,7 +111,7 @@
         </div>
       </section>
 
-      <aside id="rowDetails" aria-live="polite"></aside>
+      <aside id="rowDetails" role="region" aria-label="Row details" aria-live="polite"></aside>
     </main>
 
     <script type="module" defer src="/assets/app.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -25,10 +25,27 @@
           </select>
         </label>
 
-        <label class="filter-field">
-          Filter
-          <input id="filterInput" type="search" placeholder="Search current table" />
-        </label>
+        <div class="filter-builder">
+          <label>
+            Column
+            <select id="filterColumn"></select>
+          </label>
+
+          <label>
+            Match
+            <select id="filterOperator">
+              <option value="ilike">Contains</option>
+              <option value="eq">Equals</option>
+            </select>
+          </label>
+
+          <label class="filter-field">
+            Filter
+            <input id="filterInput" type="search" placeholder="Value" />
+          </label>
+
+          <button id="addFilter" type="button">Add</button>
+        </div>
 
         <label>
           Rows
@@ -41,6 +58,8 @@
           </select>
         </label>
       </section>
+
+      <div id="filterChips" class="filter-chips" aria-label="Active filters"></div>
 
       <section class="table-shell" aria-label="State table">
         <div class="table-status">

--- a/public/index.html
+++ b/public/index.html
@@ -96,7 +96,17 @@
         <div id="tableScroll" class="table-scroll">
           <table>
             <thead id="tableHead"></thead>
-            <tbody id="tableBody"></tbody>
+            <tbody id="tableBody">
+              <tr class="skeleton-row" aria-hidden="true">
+                <td colspan="5"><span class="skeleton-block"></span></td>
+              </tr>
+              <tr class="skeleton-row" aria-hidden="true">
+                <td colspan="5"><span class="skeleton-block"></span></td>
+              </tr>
+              <tr class="skeleton-row" aria-hidden="true">
+                <td colspan="5"><span class="skeleton-block"></span></td>
+              </tr>
+            </tbody>
           </table>
         </div>
       </section>

--- a/public/index.html
+++ b/public/index.html
@@ -78,6 +78,8 @@
         <button id="deleteSavedView" type="button">Delete</button>
       </section>
 
+      <section id="chartPanel" class="chart-panel" aria-live="polite"></section>
+
       <section class="table-shell" aria-label="State table">
         <div class="table-status">
           <p id="pageSummary">Loading rows...</p>

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>os.ubq.fi</title>
+    <script>
+      try {
+        const theme = localStorage.getItem("os.ubq.fi.theme");
+        if (theme === "dark" || theme === "light") {
+          document.documentElement.dataset.theme = theme;
+        }
+      } catch {
+        // Storage can be unavailable in restricted browser contexts.
+      }
+    </script>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -13,6 +23,15 @@
           <h1>os.ubq.fi</h1>
           <p>Operational state browser with shareable table views.</p>
         </div>
+        <button
+          id="themeToggle"
+          class="theme-toggle"
+          type="button"
+          aria-label="Switch theme"
+          aria-pressed="false"
+        >
+          Dark
+        </button>
       </header>
 
       <section class="toolbar" aria-label="Table controls">

--- a/public/index.html
+++ b/public/index.html
@@ -98,13 +98,13 @@
             <thead id="tableHead"></thead>
             <tbody id="tableBody">
               <tr class="skeleton-row" aria-hidden="true">
-                <td colspan="5"><span class="skeleton-block"></span></td>
+                <td colspan="5"><span class="skeleton-block skeleton-wide"></span></td>
               </tr>
               <tr class="skeleton-row" aria-hidden="true">
-                <td colspan="5"><span class="skeleton-block"></span></td>
+                <td colspan="5"><span class="skeleton-block skeleton-medium"></span></td>
               </tr>
               <tr class="skeleton-row" aria-hidden="true">
-                <td colspan="5"><span class="skeleton-block"></span></td>
+                <td colspan="5"><span class="skeleton-block skeleton-short"></span></td>
               </tr>
             </tbody>
           </table>

--- a/public/index.html
+++ b/public/index.html
@@ -3,39 +3,69 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>os.ubq.fi — Minimal Deno Server</title>
+    <title>os.ubq.fi</title>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
     <main>
-      <h1>os.ubq.fi</h1>
-      <p>Minimal Deno server with a simple UI and API.</p>
+      <header class="page-header">
+        <div>
+          <h1>os.ubq.fi</h1>
+          <p>Operational state browser with shareable table views.</p>
+        </div>
+      </header>
 
-      <section>
-        <h2>Health</h2>
-        <button id="checkHealth">Check Health</button>
-        <pre id="healthOut">(click to load)</pre>
+      <section class="toolbar" aria-label="Table controls">
+        <label>
+          Table
+          <select id="tableSelect">
+            <option value="users">Users</option>
+            <option value="issues">Issues</option>
+            <option value="plugins">Plugins</option>
+          </select>
+        </label>
+
+        <label class="filter-field">
+          Filter
+          <input id="filterInput" type="search" placeholder="Search current table" />
+        </label>
+
+        <label>
+          Rows
+          <select id="limitSelect">
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+            <option value="5000">5000</option>
+          </select>
+        </label>
       </section>
 
-      <section>
-        <h2>Time</h2>
-        <button id="getTime">Get Time</button>
-        <pre id="timeOut">(click to load)</pre>
+      <section class="table-shell" aria-label="State table">
+        <div class="table-status">
+          <p id="pageSummary">Loading rows...</p>
+          <div class="table-actions">
+            <button id="exportCsv" type="button">CSV</button>
+            <button id="exportJson" type="button">JSON</button>
+            <div class="pagination">
+              <button id="prevPage" type="button">Previous</button>
+              <button id="nextPage" type="button">Next</button>
+            </div>
+          </div>
+        </div>
+
+        <div id="tableScroll" class="table-scroll">
+          <table>
+            <thead id="tableHead"></thead>
+            <tbody id="tableBody"></tbody>
+          </table>
+        </div>
       </section>
 
-      <section>
-        <h2>Echo</h2>
-        <form id="echoForm">
-          <label>
-            JSON payload
-            <textarea id="echoInput" rows="4" placeholder='{"hello":"world"}'></textarea>
-          </label>
-          <button type="submit">POST /api/echo</button>
-        </form>
-        <pre id="echoOut">(submit to send)</pre>
-      </section>
+      <aside id="rowDetails" aria-live="polite"></aside>
     </main>
 
     <script type="module" defer src="/assets/app.js"></script>
   </body>
-  </html>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,23 @@
 
       <div id="filterChips" class="filter-chips" aria-label="Active filters"></div>
 
+      <section class="saved-views" aria-label="Saved views">
+        <label>
+          View name
+          <input id="savedViewName" type="text" placeholder="Name this view" />
+        </label>
+
+        <button id="saveCurrentView" type="button">Save</button>
+
+        <label>
+          Saved
+          <select id="savedViewSelect"></select>
+        </label>
+
+        <button id="applySavedView" type="button">Apply</button>
+        <button id="deleteSavedView" type="button">Delete</button>
+      </section>
+
       <section class="table-shell" aria-label="State table">
         <div class="table-status">
           <p id="pageSummary">Loading rows...</p>

--- a/public/styles.css
+++ b/public/styles.css
@@ -68,7 +68,7 @@ label,
 
 .toolbar {
   display: grid;
-  grid-template-columns: minmax(140px, 180px) minmax(220px, 1fr) minmax(110px, 140px);
+  grid-template-columns: minmax(140px, 180px) minmax(360px, 1fr) minmax(110px, 140px);
   gap: 12px;
   align-items: end;
   padding: 16px;
@@ -99,6 +99,28 @@ select:focus,
 button:focus-visible {
   outline: 3px solid #bfdbfe;
   outline-offset: 2px;
+}
+
+.filter-builder {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.8fr) minmax(110px, 0.7fr) minmax(180px, 1fr) auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 12px;
+  padding: 10px 16px;
+  border-right: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.filter-chips:empty {
+  display: none;
 }
 
 .table-shell {
@@ -194,7 +216,8 @@ tbody tr[data-row-id] {
 }
 
 .sort-button,
-.row-toggle {
+.row-toggle,
+.filter-chip {
   min-height: 32px;
   color: var(--primary);
   background: transparent;
@@ -202,10 +225,18 @@ tbody tr[data-row-id] {
 }
 
 .sort-button:hover:not(:disabled),
-.row-toggle:hover:not(:disabled) {
+.row-toggle:hover:not(:disabled),
+.filter-chip:hover:not(:disabled) {
   background: transparent;
   color: var(--primary-hover);
   text-decoration: underline;
+}
+
+.filter-chip {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: #f8fbff;
+  padding: 0 10px;
 }
 
 .details-panel {
@@ -244,6 +275,10 @@ pre {
   }
 
   .toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-builder {
     grid-template-columns: 1fr;
   }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -60,6 +60,7 @@ label,
 }
 
 .toolbar,
+.saved-views,
 .table-shell,
 .details-panel {
   border: 1px solid var(--border);
@@ -121,6 +122,15 @@ button:focus-visible {
 
 .filter-chips:empty {
   display: none;
+}
+
+.saved-views {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) auto minmax(160px, 1fr) auto auto;
+  gap: 10px;
+  align-items: end;
+  padding: 12px 16px;
+  border-top: 0;
 }
 
 .table-shell {
@@ -282,6 +292,10 @@ pre {
     grid-template-columns: 1fr;
   }
 
+  .saved-views {
+    grid-template-columns: 1fr;
+  }
+
   .table-actions,
   .pagination {
     width: 100%;
@@ -327,6 +341,7 @@ pre {
   }
 
   .toolbar,
+  .saved-views,
   .filter-chips,
   .table-actions {
     display: none;

--- a/public/styles.css
+++ b/public/styles.css
@@ -300,3 +300,90 @@ pre {
     flex: 1;
   }
 }
+
+@media print {
+  :root {
+    --bg: #ffffff;
+    --border: #9ca3af;
+    --fg: #111827;
+    --muted: #374151;
+    --panel: #ffffff;
+    --primary: #111827;
+    --row: #ffffff;
+  }
+
+  body {
+    background: white;
+  }
+
+  main {
+    width: 100%;
+    padding: 0;
+  }
+
+  .page-header {
+    display: block;
+    margin-bottom: 14px;
+  }
+
+  .toolbar,
+  .filter-chips,
+  .table-actions {
+    display: none;
+  }
+
+  .table-shell,
+  .details-panel {
+    border: 0;
+    border-radius: 0;
+  }
+
+  .table-status {
+    display: block;
+    padding: 0 0 8px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .table-scroll {
+    max-height: none;
+    overflow: visible;
+  }
+
+  table {
+    min-width: 0;
+    font-size: 10pt;
+    page-break-inside: auto;
+  }
+
+  tr,
+  .details-panel {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  th,
+  td {
+    padding: 6px 8px;
+    white-space: normal;
+  }
+
+  .sort-button,
+  .row-toggle {
+    min-height: 0;
+    color: inherit;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .details-panel {
+    margin-top: 16px;
+    padding: 0;
+  }
+
+  pre {
+    max-height: none;
+    border-color: var(--border);
+    background: white;
+    color: var(--fg);
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,13 +1,88 @@
 :root {
   color-scheme: light;
-  --bg: #f7f8fa;
-  --border: #d8dee8;
-  --fg: #18212f;
-  --muted: #657184;
-  --panel: #ffffff;
-  --primary: #1d4ed8;
-  --primary-hover: #1e40af;
-  --row: #eef4ff;
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  --font-size-xs: 0.86rem;
+  --font-size-sm: 0.9rem;
+  --font-size-md: 0.92rem;
+  --font-size-body: 1rem;
+  --font-size-lg: 1.05rem;
+  --font-size-xl: 1.7rem;
+  --font-size-print: 10pt;
+  --line-height-tight: 1.2;
+  --line-height-body: 1.5;
+  --font-weight-strong: 700;
+  --space-0: 0;
+  --space-1: 4px;
+  --space-2: 6px;
+  --space-3: 8px;
+  --space-4: 10px;
+  --space-5: 11px;
+  --space-6: 12px;
+  --space-7: 14px;
+  --space-8: 16px;
+  --space-9: 20px;
+  --space-10: 22px;
+  --space-11: 24px;
+  --space-12: 32px;
+  --control-sm: 32px;
+  --control-md: 36px;
+  --control-lg: 40px;
+  --row-height: 55px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-pill: 999px;
+  --radius-chart: 3px;
+  --color-bg: #f7f8fa;
+  --color-border: #d8dee8;
+  --color-fg: #18212f;
+  --color-muted: #657184;
+  --color-panel: #ffffff;
+  --color-panel-muted: #f2f5fa;
+  --color-panel-raised: #f8fbff;
+  --color-field-bg: #ffffff;
+  --color-primary: #1d4ed8;
+  --color-primary-hover: #1e40af;
+  --color-primary-fg: #ffffff;
+  --color-row-selected: #eef4ff;
+  --color-focus: #bfdbfe;
+  --color-chip-border-hover: #93c5fd;
+  --color-warning-border: #fdba74;
+  --color-warning-bg: #fff7ed;
+  --color-warning-fg: #9a3412;
+  --color-code-bg: #0f172a;
+  --color-code-fg: #e2e8f0;
+  --color-skeleton-start: #eef2f7;
+  --color-skeleton-mid: #dfe7f1;
+  --shadow-chip: 0 1px 3px rgb(15 23 42 / 0.08);
+  --shadow-focus-row: inset 0 0 0 1px var(--color-primary);
+  --transition-fast: 160ms ease;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #101923;
+  --color-border: #304052;
+  --color-fg: #edf4fb;
+  --color-muted: #a7b6c8;
+  --color-panel: #162232;
+  --color-panel-muted: #1d2c3f;
+  --color-panel-raised: #13263a;
+  --color-field-bg: #0d1824;
+  --color-primary: #69b3ff;
+  --color-primary-hover: #9bd0ff;
+  --color-primary-fg: #08111d;
+  --color-row-selected: #1f3a56;
+  --color-focus: #7dd3fc;
+  --color-chip-border-hover: #60a5fa;
+  --color-warning-border: #f59e0b;
+  --color-warning-bg: #2b1e0e;
+  --color-warning-fg: #fed7aa;
+  --color-code-bg: #07111e;
+  --color-code-fg: #dbeafe;
+  --color-skeleton-start: #1c2b3b;
+  --color-skeleton-mid: #2d3e50;
+  --shadow-chip: 0 1px 4px rgb(0 0 0 / 0.22);
 }
 
 * {
@@ -17,46 +92,62 @@
 html,
 body {
   min-height: 100%;
-  margin: 0;
+  margin: var(--space-0);
 }
 
 body {
-  background: var(--bg);
-  color: var(--fg);
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  line-height: 1.5;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-body);
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 main {
-  width: min(1180px, calc(100% - 32px));
-  margin: 0 auto;
-  padding: 32px 0;
+  width: min(1180px, calc(100% - var(--space-12)));
+  margin: var(--space-0) auto;
+  padding: var(--space-12) var(--space-0);
 }
 
 h1,
 h2,
 p {
-  margin: 0;
+  margin: var(--space-0);
 }
 
 .page-header {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 24px;
+  gap: var(--space-8);
+  margin-bottom: var(--space-11);
 }
 
 .page-header h1 {
-  font-size: 1.7rem;
-  line-height: 1.2;
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-tight);
+}
+
+.theme-toggle {
+  min-width: 6.5rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-panel);
+  color: var(--color-primary);
+}
+
+.theme-toggle:hover:not(:disabled) {
+  border-color: var(--color-chip-border-hover);
+  background: var(--color-panel-raised);
+  color: var(--color-primary-hover);
 }
 
 .page-header p,
 label,
 .table-status {
-  color: var(--muted);
+  color: var(--color-muted);
 }
 
 .toolbar,
@@ -64,61 +155,65 @@ label,
 .chart-panel,
 .table-shell,
 .details-panel {
-  border: 1px solid var(--border);
-  background: var(--panel);
+  border: 1px solid var(--color-border);
+  background: var(--color-panel);
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .toolbar {
   display: grid;
   grid-template-columns: minmax(140px, 180px) minmax(360px, 1fr) minmax(110px, 140px);
-  gap: 12px;
+  gap: var(--space-6);
   align-items: end;
-  padding: 16px;
-  border-radius: 8px 8px 0 0;
+  padding: var(--space-8);
+  border-radius: var(--radius-md) var(--radius-md) var(--space-0) var(--space-0);
 }
 
 label {
   display: grid;
-  gap: 6px;
-  font-size: 0.86rem;
-  font-weight: 700;
+  gap: var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-strong);
 }
 
 input,
 select {
   width: 100%;
-  min-height: 40px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: white;
-  color: var(--fg);
+  min-height: var(--control-lg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-field-bg);
+  color: var(--color-fg);
   font: inherit;
-  padding: 0 10px;
+  padding: var(--space-0) var(--space-4);
 }
 
 input:focus,
 select:focus,
 button:focus-visible {
-  outline: 3px solid #bfdbfe;
+  outline: 3px solid var(--color-focus);
   outline-offset: 2px;
 }
 
 .filter-builder {
   display: grid;
   grid-template-columns: minmax(120px, 0.8fr) minmax(110px, 0.7fr) minmax(180px, 1fr) auto;
-  gap: 10px;
+  gap: var(--space-4);
   align-items: end;
 }
 
 .filter-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-3);
   min-height: 12px;
-  padding: 10px 16px;
-  border-right: 1px solid var(--border);
-  border-left: 1px solid var(--border);
-  background: var(--panel);
+  padding: var(--space-4) var(--space-8);
+  border-right: 1px solid var(--color-border);
+  border-left: 1px solid var(--color-border);
+  background: var(--color-panel);
 }
 
 .filter-chips:empty {
@@ -128,25 +223,25 @@ button:focus-visible {
 .saved-views {
   display: grid;
   grid-template-columns: minmax(160px, 1fr) auto minmax(160px, 1fr) auto auto;
-  gap: 10px;
+  gap: var(--space-4);
   align-items: end;
-  padding: 12px 16px;
-  border-top: 0;
+  padding: var(--space-6) var(--space-8);
+  border-top: var(--space-0);
 }
 
 .chart-panel {
-  padding: 14px 16px;
-  border-top: 0;
+  padding: var(--space-7) var(--space-8);
+  border-top: var(--space-0);
 }
 
 .chart-title {
-  margin-bottom: 8px;
-  color: var(--muted);
-  font-size: 0.9rem;
+  margin-bottom: var(--space-3);
+  color: var(--color-muted);
+  font-size: var(--font-size-sm);
 }
 
 .chart-empty {
-  color: var(--muted);
+  color: var(--color-muted);
 }
 
 .chart-svg {
@@ -157,33 +252,33 @@ button:focus-visible {
 }
 
 .chart-svg text {
-  fill: var(--fg);
-  font: 700 13px Inter, ui-sans-serif, system-ui, sans-serif;
+  fill: var(--color-fg);
+  font: var(--font-weight-strong) 13px var(--font-sans);
 }
 
 .chart-svg rect {
-  fill: var(--primary);
+  fill: var(--color-primary);
 }
 
 .table-shell {
-  border-top: 0;
-  border-radius: 0 0 8px 8px;
+  border-top: var(--space-0);
+  border-radius: var(--space-0) var(--space-0) var(--radius-md) var(--radius-md);
 }
 
 .table-status {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--border);
-  font-size: 0.92rem;
+  gap: var(--space-8);
+  padding: var(--space-7) var(--space-8);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--font-size-md);
 }
 
 .table-actions,
 .pagination {
   display: flex;
-  gap: 8px;
+  gap: var(--space-3);
 }
 
 .table-actions {
@@ -191,25 +286,25 @@ button:focus-visible {
 }
 
 button {
-  min-height: 36px;
-  border: 0;
-  border-radius: 6px;
-  background: var(--primary);
-  color: white;
+  min-height: var(--control-md);
+  border: var(--space-0);
+  border-radius: var(--radius-sm);
+  background: var(--color-primary);
+  color: var(--color-primary-fg);
   cursor: pointer;
   font: inherit;
-  font-weight: 700;
-  padding: 0 12px;
+  font-weight: var(--font-weight-strong);
+  padding: var(--space-0) var(--space-6);
   transition:
-    background-color 160ms ease,
-    border-color 160ms ease,
-    box-shadow 160ms ease,
-    color 160ms ease,
-    transform 160ms ease;
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    color var(--transition-fast),
+    transform var(--transition-fast);
 }
 
 button:hover:not(:disabled) {
-  background: var(--primary-hover);
+  background: var(--color-primary-hover);
 }
 
 button:active:not(:disabled) {
@@ -234,32 +329,32 @@ table {
 
 th,
 td {
-  border-bottom: 1px solid var(--border);
-  padding: 11px 14px;
+  border-bottom: 1px solid var(--color-border);
+  padding: var(--space-5) var(--space-7);
   text-align: left;
   vertical-align: middle;
   white-space: nowrap;
 }
 
 th {
-  background: #f2f5fa;
+  background: var(--color-panel-muted);
 }
 
 tbody tr:hover {
-  background: #f8fbff;
+  background: var(--color-panel-raised);
 }
 
 tbody tr[data-row-id] {
-  height: 55px;
+  height: var(--row-height);
   transition:
-    background-color 160ms ease,
-    box-shadow 160ms ease;
+    background-color var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
 tbody tr[data-row-id]:focus-visible {
-  outline: 3px solid #bfdbfe;
+  outline: 3px solid var(--color-focus);
   outline-offset: -3px;
-  box-shadow: inset 0 0 0 1px var(--primary);
+  box-shadow: var(--shadow-focus-row);
 }
 
 .virtual-spacer,
@@ -268,22 +363,22 @@ tbody tr[data-row-id]:focus-visible {
 }
 
 .virtual-spacer td {
-  border: 0;
-  padding: 0;
+  border: var(--space-0);
+  padding: var(--space-0);
 }
 
 .selected-row {
-  background: var(--row);
+  background: var(--color-row-selected);
 }
 
 .sort-button,
 .row-toggle,
 .filter-chip,
 .related-chip {
-  min-height: 32px;
-  color: var(--primary);
+  min-height: var(--control-sm);
+  color: var(--color-primary);
   background: transparent;
-  padding: 0;
+  padding: var(--space-0);
 }
 
 .sort-button:hover:not(:disabled),
@@ -291,61 +386,61 @@ tbody tr[data-row-id]:focus-visible {
 .filter-chip:hover:not(:disabled),
 .related-chip:hover:not(:disabled) {
   background: transparent;
-  color: var(--primary-hover);
+  color: var(--color-primary-hover);
   text-decoration: underline;
 }
 
 .filter-chip,
 .related-chip {
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: #f8fbff;
-  padding: 0 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-panel-raised);
+  padding: var(--space-0) var(--space-4);
 }
 
 .filter-chip:hover:not(:disabled),
 .related-chip:hover:not(:disabled) {
-  border-color: #93c5fd;
-  box-shadow: 0 1px 3px rgb(15 23 42 / 0.08);
+  border-color: var(--color-chip-border-hover);
+  box-shadow: var(--shadow-chip);
 }
 
 .details-panel {
-  margin-top: 16px;
-  border-radius: 8px;
-  padding: 16px;
+  margin-top: var(--space-8);
+  border-radius: var(--radius-md);
+  padding: var(--space-8);
   transition:
-    border-color 160ms ease,
-    box-shadow 160ms ease;
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
 .details-panel h2 {
-  margin-bottom: 10px;
-  font-size: 1.05rem;
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-lg);
 }
 
 .related-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin: 0 0 12px;
+  gap: var(--space-3);
+  margin: var(--space-0) var(--space-0) var(--space-6);
 }
 
 .related-chip {
-  color: var(--primary);
+  color: var(--color-primary);
 }
 
 .empty-state {
   display: grid;
-  gap: 4px;
+  gap: var(--space-1);
   justify-items: center;
-  padding: 22px 12px;
-  color: var(--muted);
+  padding: var(--space-10) var(--space-6);
+  color: var(--color-muted);
   text-align: center;
   white-space: normal;
 }
 
 .empty-state strong {
-  color: var(--fg);
+  color: var(--color-fg);
   font-size: 0.95rem;
 }
 
@@ -355,24 +450,24 @@ tbody tr[data-row-id]:focus-visible {
 }
 
 .inline-error {
-  margin: 0 0 12px;
-  border: 1px solid #fdba74;
-  border-radius: 6px;
-  background: #fff7ed;
-  color: #9a3412;
-  padding: 10px 12px;
-  font-size: 0.9rem;
-  font-weight: 700;
+  margin: var(--space-0) var(--space-0) var(--space-6);
+  border: 1px solid var(--color-warning-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-warning-bg);
+  color: var(--color-warning-fg);
+  padding: var(--space-4) var(--space-6);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-strong);
 }
 
 .inspector-skeleton {
   display: grid;
-  gap: 8px;
-  margin: 0 0 12px;
+  gap: var(--space-3);
+  margin: var(--space-0) var(--space-0) var(--space-6);
 }
 
 .skeleton-row td {
-  height: 55px;
+  height: var(--row-height);
 }
 
 .skeleton-block {
@@ -380,8 +475,13 @@ tbody tr[data-row-id]:focus-visible {
   width: min(460px, 70%);
   height: 16px;
   overflow: hidden;
-  border-radius: 999px;
-  background: linear-gradient(90deg, #eef2f7 0%, #dfe7f1 45%, #eef2f7 90%);
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    90deg,
+    var(--color-skeleton-start) 0%,
+    var(--color-skeleton-mid) 45%,
+    var(--color-skeleton-start) 90%
+  );
   background-size: 240% 100%;
   animation: shimmer 1.2s ease-in-out infinite;
 }
@@ -410,20 +510,20 @@ tbody tr[data-row-id]:focus-visible {
 
 pre {
   max-height: 300px;
-  margin: 0;
+  margin: var(--space-0);
   overflow: auto;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: #0f172a;
-  color: #e2e8f0;
-  padding: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-code-bg);
+  color: var(--color-code-fg);
+  padding: var(--space-6);
   white-space: pre-wrap;
 }
 
 @media (max-width: 760px) {
   main {
     width: min(100% - 24px, 1180px);
-    padding: 20px 0;
+    padding: var(--space-9) var(--space-0);
   }
 
   .page-header,
@@ -465,51 +565,52 @@ pre {
 
 @media print {
   :root {
-    --bg: #ffffff;
-    --border: #9ca3af;
-    --fg: #111827;
-    --muted: #374151;
-    --panel: #ffffff;
-    --primary: #111827;
-    --row: #ffffff;
+    --color-bg: #ffffff;
+    --color-border: #9ca3af;
+    --color-fg: #111827;
+    --color-muted: #374151;
+    --color-panel: #ffffff;
+    --color-primary: #111827;
+    --color-row-selected: #ffffff;
   }
 
   body {
-    background: white;
+    background: var(--color-bg);
   }
 
   main {
     width: 100%;
-    padding: 0;
+    padding: var(--space-0);
   }
 
   .page-header {
     display: block;
-    margin-bottom: 14px;
+    margin-bottom: var(--space-7);
   }
 
   .toolbar,
   .saved-views,
   .filter-chips,
+  .theme-toggle,
   .table-actions {
     display: none;
   }
 
   .chart-panel {
-    padding: 0 0 10px;
-    border: 0;
+    padding: var(--space-0) var(--space-0) var(--space-4);
+    border: var(--space-0);
   }
 
   .table-shell,
   .details-panel {
-    border: 0;
-    border-radius: 0;
+    border: var(--space-0);
+    border-radius: var(--space-0);
   }
 
   .table-status {
     display: block;
-    padding: 0 0 8px;
-    border-bottom: 1px solid var(--border);
+    padding: var(--space-0) var(--space-0) var(--space-3);
+    border-bottom: 1px solid var(--color-border);
   }
 
   .table-scroll {
@@ -519,7 +620,7 @@ pre {
 
   table {
     min-width: 0;
-    font-size: 10pt;
+    font-size: var(--font-size-print);
     page-break-inside: auto;
   }
 
@@ -531,28 +632,28 @@ pre {
 
   th,
   td {
-    padding: 6px 8px;
+    padding: var(--space-2) var(--space-3);
     white-space: normal;
   }
 
   .sort-button,
   .row-toggle {
-    min-height: 0;
+    min-height: var(--space-0);
     color: inherit;
-    font-weight: 700;
+    font-weight: var(--font-weight-strong);
     text-decoration: none;
   }
 
   .details-panel {
-    margin-top: 16px;
-    padding: 0;
+    margin-top: var(--space-8);
+    padding: var(--space-0);
   }
 
   pre {
     max-height: none;
-    border-color: var(--border);
-    background: white;
-    color: var(--fg);
+    border-color: var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-fg);
   }
 }
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -61,6 +61,7 @@ label,
 
 .toolbar,
 .saved-views,
+.chart-panel,
 .table-shell,
 .details-panel {
   border: 1px solid var(--border);
@@ -131,6 +132,37 @@ button:focus-visible {
   align-items: end;
   padding: 12px 16px;
   border-top: 0;
+}
+
+.chart-panel {
+  padding: 14px 16px;
+  border-top: 0;
+}
+
+.chart-title {
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.chart-empty {
+  color: var(--muted);
+}
+
+.chart-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 170px;
+}
+
+.chart-svg text {
+  fill: var(--fg);
+  font: 700 13px Inter, ui-sans-serif, system-ui, sans-serif;
+}
+
+.chart-svg rect {
+  fill: var(--primary);
 }
 
 .table-shell {
@@ -345,6 +377,11 @@ pre {
   .filter-chips,
   .table-actions {
     display: none;
+  }
+
+  .chart-panel {
+    padding: 0 0 10px;
+    border: 0;
   }
 
   .table-shell,

--- a/public/styles.css
+++ b/public/styles.css
@@ -328,6 +328,43 @@ tbody tr[data-row-id] {
   color: var(--primary);
 }
 
+.empty-state {
+  display: grid;
+  gap: 4px;
+  justify-items: center;
+  padding: 22px 12px;
+  color: var(--muted);
+  text-align: center;
+  white-space: normal;
+}
+
+.empty-state strong {
+  color: var(--fg);
+  font-size: 0.95rem;
+}
+
+.inspector-empty {
+  min-height: 86px;
+  align-content: center;
+}
+
+.inline-error {
+  margin: 0 0 12px;
+  border: 1px solid #fdba74;
+  border-radius: 6px;
+  background: #fff7ed;
+  color: #9a3412;
+  padding: 10px 12px;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.inspector-skeleton {
+  display: grid;
+  gap: 8px;
+  margin: 0 0 12px;
+}
+
 .skeleton-row td {
   height: 55px;
 }
@@ -341,6 +378,18 @@ tbody tr[data-row-id] {
   background: linear-gradient(90deg, #eef2f7 0%, #dfe7f1 45%, #eef2f7 90%);
   background-size: 240% 100%;
   animation: shimmer 1.2s ease-in-out infinite;
+}
+
+.skeleton-wide {
+  width: min(460px, 70%);
+}
+
+.skeleton-medium {
+  width: min(320px, 56%);
+}
+
+.skeleton-short {
+  width: min(220px, 42%);
 }
 
 @keyframes shimmer {

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,32 +1,267 @@
 :root {
-  color-scheme: light dark;
-  --bg: #0b0c0f;
-  --fg: #e6e8ea;
-  --accent: #7cd7ff;
-  --muted: #9aa4af;
+  color-scheme: light;
+  --bg: #f7f8fa;
+  --border: #d8dee8;
+  --fg: #18212f;
+  --muted: #657184;
+  --panel: #ffffff;
+  --primary: #1d4ed8;
+  --primary-hover: #1e40af;
+  --row: #eef4ff;
 }
 
-* { box-sizing: border-box; }
-html, body { height: 100%; margin: 0; }
+* {
+  box-sizing: border-box;
+}
+
+html,
 body {
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-  line-height: 1.5;
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
   background: var(--bg);
   color: var(--fg);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
 }
-main { max-width: 720px; margin: 3rem auto; padding: 0 1rem; }
-h1 { font-size: 1.6rem; margin: 0 0 1rem; }
-h2 { font-size: 1.2rem; margin: 2rem 0 0.5rem; }
-section { padding: 1rem; border: 1px solid #222; border-radius: 8px; }
-button {
-  background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer;
-  padding: 0.5rem 0.75rem; font-weight: 600; letter-spacing: 0.2px;
-}
-button:hover { filter: brightness(1.05); }
-pre {
-  background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
-  overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
-}
-textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
-label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+main {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  font-size: 1.7rem;
+  line-height: 1.2;
+}
+
+.page-header p,
+label,
+.table-status {
+  color: var(--muted);
+}
+
+.toolbar,
+.table-shell,
+.details-panel {
+  border: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: minmax(140px, 180px) minmax(220px, 1fr) minmax(110px, 140px);
+  gap: 12px;
+  align-items: end;
+  padding: 16px;
+  border-radius: 8px 8px 0 0;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+input,
+select {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: white;
+  color: var(--fg);
+  font: inherit;
+  padding: 0 10px;
+}
+
+input:focus,
+select:focus,
+button:focus-visible {
+  outline: 3px solid #bfdbfe;
+  outline-offset: 2px;
+}
+
+.table-shell {
+  border-top: 0;
+  border-radius: 0 0 8px 8px;
+}
+
+.table-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.92rem;
+}
+
+.table-actions,
+.pagination {
+  display: flex;
+  gap: 8px;
+}
+
+.table-actions {
+  align-items: center;
+}
+
+button {
+  min-height: 36px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--primary);
+  color: white;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 0 12px;
+}
+
+button:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.table-scroll {
+  max-height: min(58vh, 560px);
+  overflow: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 760px;
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--border);
+  padding: 11px 14px;
+  text-align: left;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+th {
+  background: #f2f5fa;
+}
+
+tbody tr:hover {
+  background: #f8fbff;
+}
+
+tbody tr[data-row-id] {
+  height: 55px;
+}
+
+.virtual-spacer,
+.virtual-spacer:hover {
+  background: transparent;
+}
+
+.virtual-spacer td {
+  border: 0;
+  padding: 0;
+}
+
+.selected-row {
+  background: var(--row);
+}
+
+.sort-button,
+.row-toggle {
+  min-height: 32px;
+  color: var(--primary);
+  background: transparent;
+  padding: 0;
+}
+
+.sort-button:hover:not(:disabled),
+.row-toggle:hover:not(:disabled) {
+  background: transparent;
+  color: var(--primary-hover);
+  text-decoration: underline;
+}
+
+.details-panel {
+  margin-top: 16px;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.details-panel h2 {
+  margin-bottom: 10px;
+  font-size: 1.05rem;
+}
+
+pre {
+  max-height: 300px;
+  margin: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 12px;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 760px) {
+  main {
+    width: min(100% - 24px, 1180px);
+    padding: 20px 0;
+  }
+
+  .page-header,
+  .table-status {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .table-actions,
+  .pagination {
+    width: 100%;
+  }
+
+  .table-actions {
+    flex-wrap: wrap;
+  }
+
+  .pagination,
+  .table-actions > button {
+    flex: 1;
+  }
+
+  .pagination button {
+    flex: 1;
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -256,6 +256,12 @@ tbody tr[data-row-id] {
     box-shadow 160ms ease;
 }
 
+tbody tr[data-row-id]:focus-visible {
+  outline: 3px solid #bfdbfe;
+  outline-offset: -3px;
+  box-shadow: inset 0 0 0 1px var(--primary);
+}
+
 .virtual-spacer,
 .virtual-spacer:hover {
   background: transparent;

--- a/public/styles.css
+++ b/public/styles.css
@@ -200,10 +200,20 @@ button {
   font: inherit;
   font-weight: 700;
   padding: 0 12px;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
 }
 
 button:hover:not(:disabled) {
   background: var(--primary-hover);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 button:disabled {
@@ -241,6 +251,9 @@ tbody tr:hover {
 
 tbody tr[data-row-id] {
   height: 55px;
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .virtual-spacer,
@@ -259,7 +272,8 @@ tbody tr[data-row-id] {
 
 .sort-button,
 .row-toggle,
-.filter-chip {
+.filter-chip,
+.related-chip {
   min-height: 32px;
   color: var(--primary);
   background: transparent;
@@ -268,28 +282,75 @@ tbody tr[data-row-id] {
 
 .sort-button:hover:not(:disabled),
 .row-toggle:hover:not(:disabled),
-.filter-chip:hover:not(:disabled) {
+.filter-chip:hover:not(:disabled),
+.related-chip:hover:not(:disabled) {
   background: transparent;
   color: var(--primary-hover);
   text-decoration: underline;
 }
 
-.filter-chip {
+.filter-chip,
+.related-chip {
   border: 1px solid var(--border);
   border-radius: 999px;
   background: #f8fbff;
   padding: 0 10px;
 }
 
+.filter-chip:hover:not(:disabled),
+.related-chip:hover:not(:disabled) {
+  border-color: #93c5fd;
+  box-shadow: 0 1px 3px rgb(15 23 42 / 0.08);
+}
+
 .details-panel {
   margin-top: 16px;
   border-radius: 8px;
   padding: 16px;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .details-panel h2 {
   margin-bottom: 10px;
   font-size: 1.05rem;
+}
+
+.related-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 12px;
+}
+
+.related-chip {
+  color: var(--primary);
+}
+
+.skeleton-row td {
+  height: 55px;
+}
+
+.skeleton-block {
+  display: block;
+  width: min(460px, 70%);
+  height: 16px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #eef2f7 0%, #dfe7f1 45%, #eef2f7 90%);
+  background-size: 240% 100%;
+  animation: shimmer 1.2s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  from {
+    background-position: 100% 0;
+  }
+
+  to {
+    background-position: -100% 0;
+  }
 }
 
 pre {
@@ -437,5 +498,16 @@ pre {
     border-color: var(--border);
     background: white;
     color: var(--fg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,15 @@ import { serveDir } from '@std/http/file-server';
 const PUBLIC_DIR = Deno.env.get('PUBLIC_DIR') ?? 'public';
 const PORT = Number.parseInt(Deno.env.get('PORT') ?? '8000');
 
+type RelationTable = 'issues' | 'plugins' | 'users';
+
+type RelationEdge = {
+  filterKey: string;
+  label: string;
+  table: RelationTable;
+  value: string;
+};
+
 export async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const pathname = url.pathname;
@@ -18,6 +27,10 @@ export async function handler(req: Request): Promise<Response> {
       if (pathname === '/api/time' && req.method === 'GET') {
         const now = new Date();
         return json({ iso: now.toISOString(), epochMS: now.getTime() });
+      }
+
+      if (pathname === '/api/sb/relations' && req.method === 'GET') {
+        return relations(url);
       }
 
       if (pathname === '/api/echo' && req.method === 'POST') {
@@ -60,6 +73,97 @@ export async function handler(req: Request): Promise<Response> {
     console.error('Request error:', err);
     return new Response('Internal Server Error', { status: 500 });
   }
+}
+
+function relations(url: URL): Response {
+  const table = parseRelationTable(url.searchParams.get('table'));
+  const id = url.searchParams.get('id')?.trim() ?? '';
+  if (!table || !id) {
+    return json({ error: 'Expected table and id query parameters' }, { status: 400 });
+  }
+
+  const edges = getExactRelations(table, id);
+  if (!edges) {
+    return json({ error: 'No relation row found' }, { status: 404 });
+  }
+
+  return json({
+    edges,
+    id,
+    source: 'exact-fk-rpc',
+    table,
+  });
+}
+
+function parseRelationTable(value: string | null): RelationTable | null {
+  return value === 'issues' || value === 'plugins' || value === 'users' ? value : null;
+}
+
+function getExactRelations(table: RelationTable, id: string): RelationEdge[] | null {
+  if (table === 'users') {
+    const userIndex = parseRowIndex(id, 'usr');
+    if (userIndex === null) return null;
+    return [
+      {
+        filterKey: 'userId',
+        label: 'Assigned issues',
+        table: 'issues',
+        value: id,
+      },
+    ];
+  }
+
+  if (table === 'plugins') {
+    const pluginIndex = parseRowIndex(id, 'plg');
+    if (pluginIndex === null) return null;
+    return [
+      {
+        filterKey: 'pluginId',
+        label: 'Linked issues',
+        table: 'issues',
+        value: id,
+      },
+    ];
+  }
+
+  const issueIndex = parseRowIndex(id, 'iss');
+  if (issueIndex === null) return null;
+  return [
+    {
+      filterKey: 'id',
+      label: 'Reporter',
+      table: 'users',
+      value: makeRowId('usr', issueIndex),
+    },
+    {
+      filterKey: 'id',
+      label: 'Plugin',
+      table: 'plugins',
+      value: makeRowId('plg', (((issueIndex - 1) * 7) % 5000) + 1),
+    },
+    {
+      filterKey: 'repo',
+      label: 'Repository issues',
+      table: 'issues',
+      value: issueRepo(issueIndex),
+    },
+  ];
+}
+
+function parseRowIndex(id: string, prefix: 'iss' | 'plg' | 'usr'): number | null {
+  const match = new RegExp(`^${prefix}_(\\d{4})$`).exec(id);
+  if (!match) return null;
+  const index = Number.parseInt(match[1] ?? '', 10);
+  return Number.isInteger(index) && index >= 1 && index <= 5000 ? index : null;
+}
+
+function makeRowId(prefix: 'iss' | 'plg' | 'usr', index: number): string {
+  return `${prefix}_${String(index).padStart(4, '0')}`;
+}
+
+function issueRepo(index: number): string {
+  const repos = ['pay.ubq.fi', 'work.ubq.fi', 'os.ubq.fi', 'command-start-stop'];
+  return repos[(index - 1) % repos.length] ?? 'os.ubq.fi';
 }
 
 function json(data: unknown, init: ResponseInit = {}): Response {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -22,6 +22,8 @@ type Column = {
 
 type FilterOperator = 'eq' | 'ilike';
 
+type Theme = 'dark' | 'light';
+
 type ColumnFilter = {
   key: keyof Row;
   op: FilterOperator;
@@ -141,6 +143,7 @@ const DETAILS_REGION_ID = 'rowDetails';
 const LAST_TABLE_KEY = 'os.ubq.fi.lastTable';
 const SAVED_VIEWS_KEY = 'os.ubq.fi.savedViews';
 const TABLE_SCROLL_KEY = 'os.ubq.fi.tableScrollTop';
+const THEME_KEY = 'os.ubq.fi.theme';
 
 let state = parseStateFromUrl(location.search);
 let activeColumns: Column[] = [];
@@ -164,6 +167,48 @@ function byId<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
   if (!el) throw new Error(`Missing element #${id}`);
   return el as T;
+}
+
+function initTheme() {
+  const themeToggle = byId<HTMLButtonElement>('themeToggle');
+  applyTheme(loadTheme(), themeToggle);
+  themeToggle.addEventListener('click', () => {
+    const nextTheme = getCurrentTheme() === 'light' ? 'dark' : 'light';
+    saveTheme(nextTheme);
+    applyTheme(nextTheme, themeToggle);
+  });
+}
+
+function getCurrentTheme(): Theme {
+  return parseTheme(document.documentElement.dataset.theme);
+}
+
+function loadTheme(): Theme {
+  try {
+    return parseTheme(localStorage.getItem(THEME_KEY));
+  } catch {
+    return 'light';
+  }
+}
+
+function saveTheme(theme: Theme) {
+  try {
+    localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    // Theme still applies for the current page even when storage is unavailable.
+  }
+}
+
+function parseTheme(value: string | null | undefined): Theme {
+  return value === 'dark' || value === 'light' ? value : 'light';
+}
+
+function applyTheme(theme: Theme, themeToggle = byId<HTMLButtonElement>('themeToggle')) {
+  const nextTheme = theme === 'light' ? 'dark' : 'light';
+  document.documentElement.dataset.theme = theme;
+  themeToggle.textContent = nextTheme === 'dark' ? 'Dark' : 'Light';
+  themeToggle.setAttribute('aria-label', `Switch to ${nextTheme} theme`);
+  themeToggle.setAttribute('aria-pressed', String(theme === 'dark'));
 }
 
 function parseStateFromUrl(search: string): ViewState {
@@ -1252,6 +1297,8 @@ function makeDate(offset: number): string {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+  initTheme();
+
   const tableSelect = byId<HTMLSelectElement>('tableSelect');
   const limitSelect = byId<HTMLSelectElement>('limitSelect');
   const filterColumn = byId<HTMLSelectElement>('filterColumn');

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -42,6 +42,13 @@ type DrillThroughLink = {
   value: string;
 };
 
+type RelationState = {
+  key: string;
+  links: DrillThroughLink[];
+  message: string;
+  status: 'error' | 'idle' | 'loading' | 'ready';
+};
+
 type SavedView = {
   name: string;
   search: string;
@@ -139,8 +146,16 @@ let activeColumns: Column[] = [];
 let activePageRows: Row[] = [];
 let activeTotalRows = 0;
 let chartFrame = 0;
+let gridStatus: 'loading' | 'ready' = 'loading';
 let pendingChart: { rows: Row[]; table: TableKey } | null = null;
 let pendingScrollTop: number | null = null;
+let relationAbortController: AbortController | null = null;
+let relationState: RelationState = {
+  key: '',
+  links: [],
+  message: '',
+  status: 'idle',
+};
 let scrollFrame = 0;
 
 function byId<T extends HTMLElement>(id: string): T {
@@ -269,22 +284,32 @@ function render() {
   const selectedRow = sorted.find((row) => row.id === state.rowId) ?? null;
   const start = sorted.length === 0 ? 0 : offset + 1;
   const end = Math.min(offset + state.limit, sorted.length);
+  syncRelationState(state.table, selectedRow);
 
   tableSelect.value = state.table;
   limitSelect.value = String(state.limit);
   saveLastTable(state.table);
   renderFilterControls(filterColumns);
   renderSavedViews();
-  scheduleChart(state.table, sorted);
-  pageSummary.textContent = `${table.label}: ${start}-${end} of ${sorted.length}`;
-  prevPage.disabled = offset === 0;
-  nextPage.disabled = offset + state.limit >= sorted.length;
 
   activeColumns = table.columns;
   activePageRows = pageRows;
   activeTotalRows = sorted.length;
 
   tableHead.replaceChildren(renderHeader(table.columns));
+  if (gridStatus === 'loading') {
+    pageSummary.textContent = `${table.label}: loading rows`;
+    prevPage.disabled = true;
+    nextPage.disabled = true;
+    renderTableSkeletonRows(tableBody, table.columns.length + 1);
+    rowDetails.replaceChildren(renderDetails(selectedRow));
+    return;
+  }
+
+  scheduleChart(state.table, sorted);
+  pageSummary.textContent = `${table.label}: ${start}-${end} of ${sorted.length}`;
+  prevPage.disabled = offset === 0;
+  nextPage.disabled = offset + state.limit >= sorted.length;
   renderVirtualRows(tableBody, table.columns, pageRows, tableScroll);
   if (pendingScrollTop !== null) {
     tableScroll.scrollTop = pendingScrollTop;
@@ -373,11 +398,43 @@ function renderVirtualRows(
   );
 }
 
+function renderTableSkeletonRows(tableBody: HTMLTableSectionElement, colSpan: number) {
+  tableBody.replaceChildren(
+    renderSkeletonRow(colSpan, 'wide'),
+    renderSkeletonRow(colSpan, 'medium'),
+    renderSkeletonRow(colSpan, 'short'),
+    renderSkeletonRow(colSpan, 'wide'),
+  );
+}
+
+function renderSkeletonRow(
+  colSpan: number,
+  size: 'medium' | 'short' | 'wide',
+): HTMLTableRowElement {
+  const tr = document.createElement('tr');
+  tr.className = 'skeleton-row';
+  tr.setAttribute('aria-hidden', 'true');
+  const td = document.createElement('td');
+  td.colSpan = colSpan;
+  const block = document.createElement('span');
+  block.className = `skeleton-block skeleton-${size}`;
+  td.append(block);
+  tr.append(td);
+  return tr;
+}
+
 function renderEmptyRow(colSpan: number): HTMLTableRowElement {
   const tr = document.createElement('tr');
   const td = document.createElement('td');
   td.colSpan = colSpan;
-  td.textContent = 'No matching rows';
+  const empty = document.createElement('div');
+  empty.className = 'empty-state';
+  const title = document.createElement('strong');
+  title.textContent = 'No matching rows';
+  const detail = document.createElement('span');
+  detail.textContent = 'Clear filters or broaden the current search.';
+  empty.append(title, detail);
+  td.append(empty);
   tr.append(td);
   return tr;
 }
@@ -451,20 +508,179 @@ function renderDetails(row: Row | null): HTMLElement {
   const wrapper = document.createElement('div');
   wrapper.className = 'details-panel';
   if (!row) {
-    wrapper.textContent =
-      'Select a row to inspect its state. The selected row is reflected in rowId=.';
+    const empty = document.createElement('div');
+    empty.className = 'empty-state inspector-empty';
+    const title = document.createElement('strong');
+    title.textContent = 'No row selected';
+    const detail = document.createElement('span');
+    detail.textContent = 'Open a table row to inspect its state and relations.';
+    empty.append(title, detail);
+    wrapper.append(empty);
     return wrapper;
   }
 
   const heading = document.createElement('h2');
   heading.textContent = row.name;
-  const relatedLinks = renderDrillThroughLinks(getDrillThroughLinks(state.table, row));
+  const relations = getRelationStateForRow(state.table, row);
+  const relatedLinks =
+    relations.status === 'loading' ? null : renderDrillThroughLinks(relations.links);
   const pre = document.createElement('pre');
   pre.textContent = JSON.stringify(row, null, 2);
   wrapper.append(heading);
+  if (relations.status === 'loading') {
+    wrapper.append(renderInspectorSkeleton());
+  } else if (relations.status === 'error') {
+    wrapper.append(renderInlineError(relations.message));
+  }
   if (relatedLinks) wrapper.append(relatedLinks);
   wrapper.append(pre);
   return wrapper;
+}
+
+function renderInspectorSkeleton(): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'inspector-skeleton';
+  wrapper.setAttribute('aria-hidden', 'true');
+  for (const size of ['short', 'medium', 'wide'] as const) {
+    const block = document.createElement('span');
+    block.className = `skeleton-block skeleton-${size}`;
+    wrapper.append(block);
+  }
+  return wrapper;
+}
+
+function renderInlineError(message: string): HTMLElement {
+  const banner = document.createElement('div');
+  banner.className = 'inline-error';
+  banner.textContent = message;
+  return banner;
+}
+
+function getRelationStateForRow(table: TableKey, row: Row): RelationState {
+  const key = relationKey(table, row.id);
+  if (relationState.key === key) {
+    return relationState;
+  }
+  return {
+    key,
+    links: getFallbackDrillThroughLinks(table, row),
+    message: '',
+    status: 'loading',
+  };
+}
+
+function syncRelationState(table: TableKey, row: Row | null) {
+  if (!row) {
+    relationAbortController?.abort();
+    relationAbortController = null;
+    relationState = { key: '', links: [], message: '', status: 'idle' };
+    return;
+  }
+
+  const key = relationKey(table, row.id);
+  if (relationState.key === key && relationState.status !== 'idle') return;
+
+  relationAbortController?.abort();
+  const fallbackLinks = getFallbackDrillThroughLinks(table, row);
+  relationState = {
+    key,
+    links: fallbackLinks,
+    message: '',
+    status: 'loading',
+  };
+
+  const controller = new AbortController();
+  relationAbortController = controller;
+  fetchExactRelations(table, row.id, controller.signal)
+    .then((links) => {
+      if (controller.signal.aborted || !isCurrentRelationKey(key)) return;
+      relationState = {
+        key,
+        links: links.length > 0 ? links : fallbackLinks,
+        message: '',
+        status: 'ready',
+      };
+      render();
+    })
+    .catch((error: unknown) => {
+      if (controller.signal.aborted || !isCurrentRelationKey(key)) return;
+      relationState = {
+        key,
+        links: fallbackLinks,
+        message:
+          error instanceof Error && error.message
+            ? `Exact relations unavailable: ${error.message}`
+            : 'Exact relations unavailable. Showing generated links.',
+        status: 'error',
+      };
+      render();
+    });
+}
+
+async function fetchExactRelations(
+  table: TableKey,
+  rowId: string,
+  signal: AbortSignal,
+): Promise<DrillThroughLink[]> {
+  const params = new URLSearchParams({ id: rowId, table });
+  const response = await fetch(`/api/sb/relations?${params.toString()}`, { signal });
+  if (!response.ok) {
+    throw new Error(`RPC returned ${response.status}`);
+  }
+  return parseRelationPayload(await response.json());
+}
+
+function parseRelationPayload(payload: unknown): DrillThroughLink[] {
+  if (
+    !payload ||
+    typeof payload !== 'object' ||
+    !Array.isArray((payload as { edges?: unknown }).edges)
+  ) {
+    return [];
+  }
+
+  return (payload as { edges: unknown[] }).edges
+    .map((edge) => parseRelationEdge(edge))
+    .filter((edge): edge is DrillThroughLink => edge !== null);
+}
+
+function parseRelationEdge(edge: unknown): DrillThroughLink | null {
+  if (!edge || typeof edge !== 'object') return null;
+  const item = edge as Partial<Record<keyof DrillThroughLink, unknown>>;
+  const table = item.table;
+  if (
+    typeof item.filterKey !== 'string' ||
+    typeof item.label !== 'string' ||
+    typeof table !== 'string' ||
+    typeof item.value !== 'string' ||
+    !isTableKey(table)
+  ) {
+    return null;
+  }
+
+  const filterKey = item.filterKey as keyof Row;
+  if (!getFilterColumns(table).some((column) => column.key === filterKey)) {
+    return null;
+  }
+
+  return {
+    filterKey,
+    label: item.label,
+    table,
+    value: item.value,
+  };
+}
+
+function relationKey(table: TableKey, rowId: string): string {
+  return `${table}:${rowId}`;
+}
+
+function isCurrentRelationKey(key: string): boolean {
+  return relationKey(state.table, state.rowId) === key;
+}
+
+function isTableKey(value: string): value is TableKey {
+  return value === 'issues' || value === 'plugins' || value === 'users';
 }
 
 function renderDrillThroughLinks(links: DrillThroughLink[]): HTMLElement | null {
@@ -485,7 +701,7 @@ function renderDrillThroughLinks(links: DrillThroughLink[]): HTMLElement | null 
   return wrapper;
 }
 
-function getDrillThroughLinks(table: TableKey, row: Row): DrillThroughLink[] {
+function getFallbackDrillThroughLinks(table: TableKey, row: Row): DrillThroughLink[] {
   if (table === 'users') {
     return [
       {
@@ -1030,7 +1246,11 @@ window.addEventListener('DOMContentLoaded', () => {
 
   pendingScrollTop = loadTableScrollTop(state.table);
   render();
-  updateUrl('replace');
+  requestAnimationFrame(() => {
+    gridStatus = 'ready';
+    render();
+    updateUrl('replace');
+  });
 });
 
 function shouldResetVirtualScroll(previous: ViewState, next: ViewState): boolean {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -18,6 +18,14 @@ type Column = {
   label: string;
 };
 
+type FilterOperator = 'eq' | 'ilike';
+
+type ColumnFilter = {
+  key: keyof Row;
+  op: FilterOperator;
+  value: string;
+};
+
 type ViewState = {
   desc: boolean;
   filters: string;
@@ -74,6 +82,10 @@ const DEFAULT_STATE: ViewState = {
 const LIMITS = [10, 25, 50, 100, 5000];
 const ROW_HEIGHT = 55;
 const OVERSCAN_ROWS = 8;
+const FILTER_OPERATORS: Record<FilterOperator, string> = {
+  eq: 'equals',
+  ilike: 'contains',
+};
 
 let state = parseStateFromUrl(location.search);
 let activeColumns: Column[] = [];
@@ -96,7 +108,7 @@ function parseStateFromUrl(search: string): ViewState {
 
   return {
     desc: params.get('desc') === 'true',
-    filters: params.get('filters')?.trim() ?? DEFAULT_STATE.filters,
+    filters: normalizeFilters(params.get('filters'), columns),
     limit: parseLimit(params.get('limit')),
     offset: parseNonNegativeInt(params.get('offset'), DEFAULT_STATE.offset),
     rowId: params.get('rowId')?.trim() ?? DEFAULT_STATE.rowId,
@@ -177,7 +189,6 @@ function serializeState(current: ViewState): URLSearchParams {
 function render() {
   const tableSelect = byId<HTMLSelectElement>('tableSelect');
   const limitSelect = byId<HTMLSelectElement>('limitSelect');
-  const filterInput = byId<HTMLInputElement>('filterInput');
   const pageSummary = byId<HTMLParagraphElement>('pageSummary');
   const prevPage = byId<HTMLButtonElement>('prevPage');
   const nextPage = byId<HTMLButtonElement>('nextPage');
@@ -206,7 +217,7 @@ function render() {
 
   tableSelect.value = state.table;
   limitSelect.value = String(state.limit);
-  filterInput.value = state.filters;
+  renderFilterControls(table.columns);
   pageSummary.textContent = `${table.label}: ${start}-${end} of ${sorted.length}`;
   prevPage.disabled = offset === 0;
   nextPage.disabled = offset + state.limit >= sorted.length;
@@ -222,6 +233,54 @@ function render() {
   tableHead.replaceChildren(renderHeader(table.columns));
   renderVirtualRows(tableBody, table.columns, pageRows, tableScroll);
   rowDetails.replaceChildren(renderDetails(selectedRow));
+}
+
+function renderFilterControls(columns: Column[]) {
+  const filterColumn = byId<HTMLSelectElement>('filterColumn');
+  const filterChips = byId<HTMLDivElement>('filterChips');
+  const selectedColumn = columns.some((column) => column.key === filterColumn.value)
+    ? filterColumn.value
+    : String(columns[0]?.key ?? 'name');
+  filterColumn.replaceChildren(
+    ...columns.map((column) => {
+      const option = document.createElement('option');
+      option.value = String(column.key);
+      option.textContent = column.label;
+      return option;
+    }),
+  );
+  filterColumn.value = selectedColumn;
+  filterChips.replaceChildren(
+    ...parseFilters(state.filters, columns).map((filter, index) =>
+      renderFilterChip(filter, columns, index),
+    ),
+  );
+}
+
+function renderFilterChip(
+  filter: ColumnFilter,
+  columns: Column[],
+  index: number,
+): HTMLButtonElement {
+  const button = document.createElement('button');
+  const label = columns.find((column) => column.key === filter.key)?.label ?? String(filter.key);
+  button.type = 'button';
+  button.className = 'filter-chip';
+  button.textContent = `${label} ${FILTER_OPERATORS[filter.op]} ${filter.value} ×`;
+  button.setAttribute(
+    'aria-label',
+    `Remove filter ${label} ${FILTER_OPERATORS[filter.op]} ${filter.value}`,
+  );
+  button.addEventListener('click', () => {
+    const filters = parseFilters(state.filters, columns);
+    filters.splice(index, 1);
+    setState({
+      filters: serializeFilters(filters),
+      offset: 0,
+      rowId: '',
+    });
+  });
+  return button;
 }
 
 function renderVirtualRows(
@@ -347,9 +406,17 @@ function renderDetails(row: Row | null): HTMLElement {
 }
 
 function filterRows(rows: Row[], query: string): Row[] {
-  const normalized = query.toLowerCase();
-  if (!normalized) return rows;
-  return rows.filter((row) => Object.values(row).join(' ').toLowerCase().includes(normalized));
+  const filters = parseFilters(query, TABLES[state.table].columns);
+  if (filters.length === 0) return rows;
+  return rows.filter((row) =>
+    filters.every((filter) => {
+      const cellValue = String(row[filter.key] ?? '');
+      if (filter.op === 'eq') {
+        return cellValue.toLowerCase() === filter.value.toLowerCase();
+      }
+      return cellValue.toLowerCase().includes(filter.value.toLowerCase());
+    }),
+  );
 }
 
 function sortRows(rows: Row[], sort: keyof Row, desc: boolean): Row[] {
@@ -359,6 +426,37 @@ function sortRows(rows: Row[], sort: keyof Row, desc: boolean): Row[] {
     const rightValue = String(right[sort] ?? '');
     return leftValue.localeCompare(rightValue, undefined, { numeric: true }) * direction;
   });
+}
+
+function parseFilters(value: string, columns: Column[]): ColumnFilter[] {
+  if (!value) return [];
+  const columnKeys = new Set(columns.map((column) => column.key));
+  return value
+    .split(',')
+    .map((part) => {
+      const [key, op, ...rawValueParts] = part.split('.');
+      const rawValue = rawValueParts.join('.');
+      if (!key || !isFilterOperator(op) || !columnKeys.has(key as keyof Row) || !rawValue) {
+        return null;
+      }
+      const decodedValue = decodeURIComponent(rawValue).trim();
+      return decodedValue ? { key: key as keyof Row, op, value: decodedValue } : null;
+    })
+    .filter((filter): filter is ColumnFilter => filter !== null);
+}
+
+function normalizeFilters(value: string | null, columns: Column[]): string {
+  return serializeFilters(parseFilters(value?.trim() ?? DEFAULT_STATE.filters, columns));
+}
+
+function serializeFilters(filters: ColumnFilter[]): string {
+  return filters
+    .map((filter) => `${String(filter.key)}.${filter.op}.${encodeURIComponent(filter.value)}`)
+    .join(',');
+}
+
+function isFilterOperator(value: string | undefined): value is FilterOperator {
+  return value === 'eq' || value === 'ilike';
 }
 
 function exportCurrentView(format: 'csv' | 'json') {
@@ -464,7 +562,10 @@ function makeDate(offset: number): string {
 window.addEventListener('DOMContentLoaded', () => {
   const tableSelect = byId<HTMLSelectElement>('tableSelect');
   const limitSelect = byId<HTMLSelectElement>('limitSelect');
+  const filterColumn = byId<HTMLSelectElement>('filterColumn');
   const filterInput = byId<HTMLInputElement>('filterInput');
+  const filterOperator = byId<HTMLSelectElement>('filterOperator');
+  const addFilter = byId<HTMLButtonElement>('addFilter');
   const exportCsv = byId<HTMLButtonElement>('exportCsv');
   const exportJson = byId<HTMLButtonElement>('exportJson');
   const prevPage = byId<HTMLButtonElement>('prevPage');
@@ -487,8 +588,28 @@ window.addEventListener('DOMContentLoaded', () => {
     setState({ limit: parseLimit(limitSelect.value), offset: 0 });
   });
 
-  filterInput.addEventListener('input', () => {
-    setState({ filters: filterInput.value.trim(), offset: 0, rowId: '' });
+  addFilter.addEventListener('click', () => {
+    const value = filterInput.value.trim();
+    const table = TABLES[state.table];
+    const key = parseColumn(filterColumn.value, table.columns);
+    const op = isFilterOperator(filterOperator.value) ? filterOperator.value : 'ilike';
+    if (!value) return;
+
+    setState({
+      filters: serializeFilters([
+        ...parseFilters(state.filters, table.columns),
+        { key, op, value },
+      ]),
+      offset: 0,
+      rowId: '',
+    });
+    filterInput.value = '';
+  });
+
+  filterInput.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    addFilter.click();
   });
 
   exportCsv.addEventListener('click', () => {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,20 +1,86 @@
-type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+/// <reference lib="dom" />
 
-async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
-  const res = await fetch(path, options);
-  const text = await res.text();
-  let data: unknown = text;
-  try {
-    data = JSON.parse(text);
-  } catch {
-    // keep text as-is
-  }
-  return { ok: res.ok, status: res.status, data };
-}
+type TableKey = 'users' | 'issues' | 'plugins';
 
-function show(el: HTMLElement, value: unknown) {
-  el.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
-}
+type Row = {
+  id: string;
+  created: string;
+  email?: string;
+  health?: string;
+  name: string;
+  owner?: string;
+  repo?: string;
+  status: string;
+};
+
+type Column = {
+  key: keyof Row;
+  label: string;
+};
+
+type ViewState = {
+  desc: boolean;
+  filters: string;
+  limit: number;
+  offset: number;
+  rowId: string;
+  sort: keyof Row;
+  table: TableKey;
+};
+
+const TABLES: Record<TableKey, { label: string; columns: Column[]; rows: Row[] }> = {
+  users: {
+    label: 'Users',
+    columns: [
+      { key: 'name', label: 'Name' },
+      { key: 'email', label: 'Email' },
+      { key: 'status', label: 'Status' },
+      { key: 'created', label: 'Created' },
+    ],
+    rows: makeUsers(),
+  },
+  issues: {
+    label: 'Issues',
+    columns: [
+      { key: 'name', label: 'Title' },
+      { key: 'repo', label: 'Repository' },
+      { key: 'status', label: 'Status' },
+      { key: 'created', label: 'Created' },
+    ],
+    rows: makeIssues(),
+  },
+  plugins: {
+    label: 'Plugins',
+    columns: [
+      { key: 'name', label: 'Plugin' },
+      { key: 'owner', label: 'Owner' },
+      { key: 'health', label: 'Health' },
+      { key: 'created', label: 'Created' },
+    ],
+    rows: makePlugins(),
+  },
+};
+
+const DEFAULT_STATE: ViewState = {
+  desc: false,
+  filters: '',
+  limit: 25,
+  offset: 0,
+  rowId: '',
+  sort: 'created',
+  table: 'users',
+};
+
+const LIMITS = [10, 25, 50, 100, 5000];
+const ROW_HEIGHT = 55;
+const OVERSCAN_ROWS = 8;
+
+let state = parseStateFromUrl(location.search);
+let activeColumns: Column[] = [];
+let activePageRows: Row[] = [];
+let activeTotalRows = 0;
+let pendingScrollTop: number | null = null;
+let scrollFrame = 0;
 
 function byId<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
@@ -22,39 +88,458 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-  const healthBtn = byId<HTMLButtonElement>('checkHealth');
-  const healthOut = byId<HTMLPreElement>('healthOut');
-  const timeBtn = byId<HTMLButtonElement>('getTime');
-  const timeOut = byId<HTMLPreElement>('timeOut');
-  const echoForm = byId<HTMLFormElement>('echoForm');
-  const echoInput = byId<HTMLTextAreaElement>('echoInput');
-  const echoOut = byId<HTMLPreElement>('echoOut');
+function parseStateFromUrl(search: string): ViewState {
+  const params = new URLSearchParams(search);
+  const table = parseTable(params.get('table'));
+  const columns = TABLES[table].columns;
+  const sort = parseColumn(params.get('sort'), columns);
 
-  healthBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/health');
-    show(healthOut, res);
-  });
+  return {
+    desc: params.get('desc') === 'true',
+    filters: params.get('filters')?.trim() ?? DEFAULT_STATE.filters,
+    limit: parseLimit(params.get('limit')),
+    offset: parseNonNegativeInt(params.get('offset'), DEFAULT_STATE.offset),
+    rowId: params.get('rowId')?.trim() ?? DEFAULT_STATE.rowId,
+    sort,
+    table,
+  };
+}
 
-  timeBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/time');
-    show(timeOut, res);
-  });
+function parseTable(value: string | null): TableKey {
+  if (value === 'issues' || value === 'plugins' || value === 'users') {
+    return value;
+  }
+  return DEFAULT_STATE.table;
+}
 
-  echoForm.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    const bodyText = echoInput.value || '{}';
-    try {
-      JSON.parse(bodyText);
-    } catch (err) {
-      show(echoOut, { error: 'Invalid JSON', details: String(err) });
-      return;
-    }
-    const res = await fetchJSON('/api/echo', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: bodyText,
+function parseColumn(value: string | null, columns: Column[]): keyof Row {
+  const column = columns.find((item) => item.key === value);
+  return column?.key ?? DEFAULT_STATE.sort;
+}
+
+function parseLimit(value: string | null): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return LIMITS.includes(parsed) ? parsed : DEFAULT_STATE.limit;
+}
+
+function parseNonNegativeInt(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function setState(next: Partial<ViewState>, mode: 'push' | 'replace' = 'push') {
+  const nextTable = next.table ?? state.table;
+  const validSort = TABLES[nextTable].columns.some(
+    (column) => column.key === (next.sort ?? state.sort),
+  );
+  const shouldResetScroll =
+    next.desc !== undefined ||
+    next.filters !== undefined ||
+    next.limit !== undefined ||
+    next.offset !== undefined ||
+    next.sort !== undefined ||
+    next.table !== undefined;
+  if (shouldResetScroll) {
+    pendingScrollTop = 0;
+  }
+  state = {
+    ...state,
+    ...next,
+    sort: validSort ? (next.sort ?? state.sort) : DEFAULT_STATE.sort,
+  };
+  render();
+  updateUrl(mode);
+}
+
+function updateUrl(mode: 'push' | 'replace') {
+  const url = new URL(location.href);
+  url.search = serializeState(state).toString();
+
+  if (`${url.pathname}${url.search}` === `${location.pathname}${location.search}`) {
+    return;
+  }
+
+  history[mode === 'replace' ? 'replaceState' : 'pushState'](state, '', url);
+}
+
+function serializeState(current: ViewState): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set('table', current.table);
+  params.set('offset', String(current.offset));
+  params.set('limit', String(current.limit));
+  params.set('sort', String(current.sort));
+  params.set('desc', String(current.desc));
+  if (current.filters) params.set('filters', current.filters);
+  if (current.rowId) params.set('rowId', current.rowId);
+  return params;
+}
+
+function render() {
+  const tableSelect = byId<HTMLSelectElement>('tableSelect');
+  const limitSelect = byId<HTMLSelectElement>('limitSelect');
+  const filterInput = byId<HTMLInputElement>('filterInput');
+  const pageSummary = byId<HTMLParagraphElement>('pageSummary');
+  const prevPage = byId<HTMLButtonElement>('prevPage');
+  const nextPage = byId<HTMLButtonElement>('nextPage');
+  const tableScroll = byId<HTMLDivElement>('tableScroll');
+  const tableHead = byId<HTMLTableSectionElement>('tableHead');
+  const tableBody = byId<HTMLTableSectionElement>('tableBody');
+  const rowDetails = byId<HTMLElement>('rowDetails');
+
+  const table = TABLES[state.table];
+  const filtered = filterRows(table.rows, state.filters);
+  const sorted = sortRows(filtered, state.sort, state.desc);
+  const maxOffset = Math.max(
+    0,
+    Math.floor(Math.max(0, sorted.length - 1) / state.limit) * state.limit,
+  );
+  const offset = Math.min(state.offset, maxOffset);
+  if (offset !== state.offset) {
+    state = { ...state, offset };
+    updateUrl('replace');
+  }
+
+  const pageRows = sorted.slice(offset, offset + state.limit);
+  const selectedRow = sorted.find((row) => row.id === state.rowId) ?? null;
+  const start = sorted.length === 0 ? 0 : offset + 1;
+  const end = Math.min(offset + state.limit, sorted.length);
+
+  tableSelect.value = state.table;
+  limitSelect.value = String(state.limit);
+  filterInput.value = state.filters;
+  pageSummary.textContent = `${table.label}: ${start}-${end} of ${sorted.length}`;
+  prevPage.disabled = offset === 0;
+  nextPage.disabled = offset + state.limit >= sorted.length;
+
+  activeColumns = table.columns;
+  activePageRows = pageRows;
+  activeTotalRows = sorted.length;
+  if (pendingScrollTop !== null) {
+    tableScroll.scrollTop = pendingScrollTop;
+    pendingScrollTop = null;
+  }
+
+  tableHead.replaceChildren(renderHeader(table.columns));
+  renderVirtualRows(tableBody, table.columns, pageRows, tableScroll);
+  rowDetails.replaceChildren(renderDetails(selectedRow));
+}
+
+function renderVirtualRows(
+  tableBody: HTMLTableSectionElement,
+  columns: Column[],
+  rows: Row[],
+  scrollEl: HTMLElement,
+) {
+  if (rows.length === 0) {
+    tableBody.replaceChildren(renderEmptyRow(columns.length + 1));
+    return;
+  }
+
+  const viewportHeight = scrollEl.clientHeight || ROW_HEIGHT * 12;
+  const maxScrollTop = Math.max(0, rows.length * ROW_HEIGHT - viewportHeight);
+  if (scrollEl.scrollTop > maxScrollTop) {
+    scrollEl.scrollTop = maxScrollTop;
+  }
+
+  const firstVisible = Math.max(0, Math.floor(scrollEl.scrollTop / ROW_HEIGHT) - OVERSCAN_ROWS);
+  const visibleCount = Math.ceil(viewportHeight / ROW_HEIGHT) + OVERSCAN_ROWS * 2;
+  const lastVisible = Math.min(rows.length, firstVisible + visibleCount);
+  const topHeight = firstVisible * ROW_HEIGHT;
+  const bottomHeight = Math.max(0, (rows.length - lastVisible) * ROW_HEIGHT);
+  const visibleRows = rows.slice(firstVisible, lastVisible).map((row) => renderRow(row, columns));
+
+  tableBody.replaceChildren(
+    renderSpacerRow(topHeight, columns.length + 1),
+    ...visibleRows,
+    renderSpacerRow(bottomHeight, columns.length + 1),
+  );
+}
+
+function renderEmptyRow(colSpan: number): HTMLTableRowElement {
+  const tr = document.createElement('tr');
+  const td = document.createElement('td');
+  td.colSpan = colSpan;
+  td.textContent = 'No matching rows';
+  tr.append(td);
+  return tr;
+}
+
+function renderSpacerRow(height: number, colSpan: number): HTMLTableRowElement {
+  const tr = document.createElement('tr');
+  tr.className = 'virtual-spacer';
+  tr.setAttribute('aria-hidden', 'true');
+  const td = document.createElement('td');
+  td.colSpan = colSpan;
+  td.style.height = `${height}px`;
+  tr.append(td);
+  return tr;
+}
+
+function renderHeader(columns: Column[]): HTMLTableRowElement {
+  const tr = document.createElement('tr');
+  for (const column of columns) {
+    const th = document.createElement('th');
+    const button = document.createElement('button');
+    const isActive = state.sort === column.key;
+    button.type = 'button';
+    button.className = 'sort-button';
+    button.textContent = `${column.label}${isActive ? (state.desc ? ' ↓' : ' ↑') : ''}`;
+    button.setAttribute('aria-sort', isActive ? (state.desc ? 'descending' : 'ascending') : 'none');
+    button.addEventListener('click', () => {
+      setState({
+        desc: isActive ? !state.desc : false,
+        offset: 0,
+        sort: column.key,
+      });
     });
-    show(echoOut, res);
+    th.append(button);
+    tr.append(th);
+  }
+
+  const th = document.createElement('th');
+  th.textContent = 'Details';
+  tr.append(th);
+  return tr;
+}
+
+function renderRow(row: Row, columns: Column[]): HTMLTableRowElement {
+  const tr = document.createElement('tr');
+  tr.dataset.rowId = row.id;
+  if (row.id === state.rowId) {
+    tr.classList.add('selected-row');
+  }
+
+  for (const column of columns) {
+    const td = document.createElement('td');
+    td.textContent = String(row[column.key] ?? '');
+    tr.append(td);
+  }
+
+  const action = document.createElement('td');
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'row-toggle';
+  button.textContent = row.id === state.rowId ? 'Close' : 'Open';
+  button.setAttribute('aria-expanded', String(row.id === state.rowId));
+  button.addEventListener('click', () => {
+    setState({ rowId: state.rowId === row.id ? '' : row.id });
   });
+  action.append(button);
+  tr.append(action);
+  return tr;
+}
+
+function renderDetails(row: Row | null): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'details-panel';
+  if (!row) {
+    wrapper.textContent =
+      'Select a row to inspect its state. The selected row is reflected in rowId=.';
+    return wrapper;
+  }
+
+  const heading = document.createElement('h2');
+  heading.textContent = row.name;
+  const pre = document.createElement('pre');
+  pre.textContent = JSON.stringify(row, null, 2);
+  wrapper.append(heading, pre);
+  return wrapper;
+}
+
+function filterRows(rows: Row[], query: string): Row[] {
+  const normalized = query.toLowerCase();
+  if (!normalized) return rows;
+  return rows.filter((row) => Object.values(row).join(' ').toLowerCase().includes(normalized));
+}
+
+function sortRows(rows: Row[], sort: keyof Row, desc: boolean): Row[] {
+  const direction = desc ? -1 : 1;
+  return [...rows].sort((left, right) => {
+    const leftValue = String(left[sort] ?? '');
+    const rightValue = String(right[sort] ?? '');
+    return leftValue.localeCompare(rightValue, undefined, { numeric: true }) * direction;
+  });
+}
+
+function exportCurrentView(format: 'csv' | 'json') {
+  const table = TABLES[state.table];
+  const fileBase = `os-ubq-fi-${state.table}-${state.offset + 1}-${state.offset + activePageRows.length}`;
+
+  if (format === 'csv') {
+    const header = activeColumns.map((column) => encodeCsvCell(column.label)).join(',');
+    const rows = activePageRows.map((row) =>
+      activeColumns.map((column) => encodeCsvCell(String(row[column.key] ?? ''))).join(','),
+    );
+    downloadBlob(
+      `\uFEFF${[header, ...rows].join('\r\n')}\r\n`,
+      'text/csv;charset=utf-8',
+      `${fileBase}.csv`,
+    );
+    return;
+  }
+
+  const payload = {
+    columns: activeColumns.map((column) => ({
+      key: column.key,
+      label: column.label,
+    })),
+    meta: {
+      desc: state.desc,
+      exportedRows: activePageRows.length,
+      filters: state.filters,
+      generatedAt: new Date().toISOString(),
+      limit: state.limit,
+      offset: state.offset,
+      rowId: state.rowId,
+      sort: state.sort,
+      table: state.table,
+      tableLabel: table.label,
+      totalRows: activeTotalRows,
+    },
+    rows: activePageRows.map((row) =>
+      Object.fromEntries(activeColumns.map((column) => [column.key, row[column.key] ?? ''])),
+    ),
+  };
+  downloadBlob(JSON.stringify(payload, null, 2), 'application/json', `${fileBase}.json`);
+}
+
+function encodeCsvCell(value: string): string {
+  const safeValue = /^[=+\-@]/.test(value) ? `'${value}` : value;
+  return /[",\r\n]/.test(safeValue) ? `"${safeValue.replace(/"/g, '""')}"` : safeValue;
+}
+
+function downloadBlob(contents: string, type: string, filename: string) {
+  const url = URL.createObjectURL(new Blob([contents], { type }));
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.style.display = 'none';
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function makeUsers(): Row[] {
+  const statuses = ['active', 'pending', 'suspended'];
+  return Array.from({ length: 5000 }, (_, index) => ({
+    id: `usr_${String(index + 1).padStart(4, '0')}`,
+    created: makeDate(index),
+    email: `user${index + 1}@ubq.fi`,
+    name: `User ${index + 1}`,
+    status: statuses[index % statuses.length] ?? 'active',
+  }));
+}
+
+function makeIssues(): Row[] {
+  const repos = ['pay.ubq.fi', 'work.ubq.fi', 'os.ubq.fi', 'command-start-stop'];
+  const statuses = ['priced', 'assigned', 'review', 'blocked'];
+  return Array.from({ length: 5000 }, (_, index) => ({
+    id: `iss_${String(index + 1).padStart(4, '0')}`,
+    created: makeDate(index * 2),
+    name: `Issue ${index + 1}: workflow follow-up`,
+    repo: repos[index % repos.length] ?? 'os.ubq.fi',
+    status: statuses[index % statuses.length] ?? 'priced',
+  }));
+}
+
+function makePlugins(): Row[] {
+  const owners = ['ubiquity-os-marketplace', 'ubiquity', '0x4007'];
+  const health = ['healthy', 'warning', 'failing'];
+  return Array.from({ length: 5000 }, (_, index) => ({
+    id: `plg_${String(index + 1).padStart(4, '0')}`,
+    created: makeDate(index * 3),
+    health: health[index % health.length] ?? 'healthy',
+    name: `Plugin ${index + 1}`,
+    owner: owners[index % owners.length] ?? 'ubiquity-os-marketplace',
+    status: 'monitored',
+  }));
+}
+
+function makeDate(offset: number): string {
+  const date = new Date(Date.UTC(2026, 0, 1 + offset));
+  return date.toISOString().slice(0, 10);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const tableSelect = byId<HTMLSelectElement>('tableSelect');
+  const limitSelect = byId<HTMLSelectElement>('limitSelect');
+  const filterInput = byId<HTMLInputElement>('filterInput');
+  const exportCsv = byId<HTMLButtonElement>('exportCsv');
+  const exportJson = byId<HTMLButtonElement>('exportJson');
+  const prevPage = byId<HTMLButtonElement>('prevPage');
+  const nextPage = byId<HTMLButtonElement>('nextPage');
+  const tableScroll = byId<HTMLDivElement>('tableScroll');
+
+  tableSelect.addEventListener('change', () => {
+    const table = parseTable(tableSelect.value);
+    setState({
+      desc: DEFAULT_STATE.desc,
+      filters: '',
+      offset: 0,
+      rowId: '',
+      sort: DEFAULT_STATE.sort,
+      table,
+    });
+  });
+
+  limitSelect.addEventListener('change', () => {
+    setState({ limit: parseLimit(limitSelect.value), offset: 0 });
+  });
+
+  filterInput.addEventListener('input', () => {
+    setState({ filters: filterInput.value.trim(), offset: 0, rowId: '' });
+  });
+
+  exportCsv.addEventListener('click', () => {
+    exportCurrentView('csv');
+  });
+
+  exportJson.addEventListener('click', () => {
+    exportCurrentView('json');
+  });
+
+  prevPage.addEventListener('click', () => {
+    setState({ offset: Math.max(0, state.offset - state.limit) });
+  });
+
+  nextPage.addEventListener('click', () => {
+    setState({ offset: state.offset + state.limit });
+  });
+
+  window.addEventListener('popstate', () => {
+    const previous = state;
+    state = parseStateFromUrl(location.search);
+    if (shouldResetVirtualScroll(previous, state)) {
+      pendingScrollTop = 0;
+    }
+    render();
+  });
+
+  tableScroll.addEventListener('scroll', () => {
+    if (scrollFrame) return;
+    scrollFrame = requestAnimationFrame(() => {
+      scrollFrame = 0;
+      renderVirtualRows(
+        byId<HTMLTableSectionElement>('tableBody'),
+        activeColumns,
+        activePageRows,
+        tableScroll,
+      );
+    });
+  });
+
+  render();
+  updateUrl('replace');
 });
+
+function shouldResetVirtualScroll(previous: ViewState, next: ViewState): boolean {
+  return (
+    previous.desc !== next.desc ||
+    previous.filters !== next.filters ||
+    previous.limit !== next.limit ||
+    previous.offset !== next.offset ||
+    previous.sort !== next.sort ||
+    previous.table !== next.table
+  );
+}

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -9,8 +9,10 @@ type Row = {
   health?: string;
   name: string;
   owner?: string;
+  pluginId?: string;
   repo?: string;
   status: string;
+  userId?: string;
 };
 
 type Column = {
@@ -23,6 +25,20 @@ type FilterOperator = 'eq' | 'ilike';
 type ColumnFilter = {
   key: keyof Row;
   op: FilterOperator;
+  value: string;
+};
+
+type TableConfig = {
+  label: string;
+  columns: Column[];
+  filters: Column[];
+  rows: Row[];
+};
+
+type DrillThroughLink = {
+  filterKey: keyof Row;
+  label: string;
+  table: TableKey;
   value: string;
 };
 
@@ -41,7 +57,7 @@ type ViewState = {
   table: TableKey;
 };
 
-const TABLES: Record<TableKey, { label: string; columns: Column[]; rows: Row[] }> = {
+const TABLES: Record<TableKey, TableConfig> = {
   users: {
     label: 'Users',
     columns: [
@@ -49,6 +65,13 @@ const TABLES: Record<TableKey, { label: string; columns: Column[]; rows: Row[] }
       { key: 'email', label: 'Email' },
       { key: 'status', label: 'Status' },
       { key: 'created', label: 'Created' },
+    ],
+    filters: [
+      { key: 'name', label: 'Name' },
+      { key: 'email', label: 'Email' },
+      { key: 'status', label: 'Status' },
+      { key: 'created', label: 'Created' },
+      { key: 'id', label: 'ID' },
     ],
     rows: makeUsers(),
   },
@@ -60,6 +83,15 @@ const TABLES: Record<TableKey, { label: string; columns: Column[]; rows: Row[] }
       { key: 'status', label: 'Status' },
       { key: 'created', label: 'Created' },
     ],
+    filters: [
+      { key: 'name', label: 'Title' },
+      { key: 'repo', label: 'Repository' },
+      { key: 'status', label: 'Status' },
+      { key: 'created', label: 'Created' },
+      { key: 'id', label: 'ID' },
+      { key: 'userId', label: 'User ID' },
+      { key: 'pluginId', label: 'Plugin ID' },
+    ],
     rows: makeIssues(),
   },
   plugins: {
@@ -69,6 +101,13 @@ const TABLES: Record<TableKey, { label: string; columns: Column[]; rows: Row[] }
       { key: 'owner', label: 'Owner' },
       { key: 'health', label: 'Health' },
       { key: 'created', label: 'Created' },
+    ],
+    filters: [
+      { key: 'name', label: 'Plugin' },
+      { key: 'owner', label: 'Owner' },
+      { key: 'health', label: 'Health' },
+      { key: 'created', label: 'Created' },
+      { key: 'id', label: 'ID' },
     ],
     rows: makePlugins(),
   },
@@ -91,7 +130,9 @@ const FILTER_OPERATORS: Record<FilterOperator, string> = {
   eq: 'equals',
   ilike: 'contains',
 };
+const LAST_TABLE_KEY = 'os.ubq.fi.lastTable';
 const SAVED_VIEWS_KEY = 'os.ubq.fi.savedViews';
+const TABLE_SCROLL_KEY = 'os.ubq.fi.tableScrollTop';
 
 let state = parseStateFromUrl(location.search);
 let activeColumns: Column[] = [];
@@ -110,13 +151,14 @@ function byId<T extends HTMLElement>(id: string): T {
 
 function parseStateFromUrl(search: string): ViewState {
   const params = new URLSearchParams(search);
-  const table = parseTable(params.get('table'));
+  const table = parseTable(params.get('table') ?? loadLastTable());
   const columns = TABLES[table].columns;
+  const filterColumns = getFilterColumns(table);
   const sort = parseColumn(params.get('sort'), columns);
 
   return {
     desc: params.get('desc') === 'true',
-    filters: normalizeFilters(params.get('filters'), columns),
+    filters: normalizeFilters(params.get('filters'), filterColumns),
     limit: parseLimit(params.get('limit')),
     offset: parseNonNegativeInt(params.get('offset'), DEFAULT_STATE.offset),
     rowId: params.get('rowId')?.trim() ?? DEFAULT_STATE.rowId,
@@ -135,6 +177,10 @@ function parseTable(value: string | null): TableKey {
 function parseColumn(value: string | null, columns: Column[]): keyof Row {
   const column = columns.find((item) => item.key === value);
   return column?.key ?? DEFAULT_STATE.sort;
+}
+
+function getFilterColumns(table: TableKey): Column[] {
+  return TABLES[table].filters;
 }
 
 function parseLimit(value: string | null): number {
@@ -206,7 +252,8 @@ function render() {
   const rowDetails = byId<HTMLElement>('rowDetails');
 
   const table = TABLES[state.table];
-  const filtered = filterRows(table.rows, state.filters);
+  const filterColumns = getFilterColumns(state.table);
+  const filtered = filterRowsForTable(state.table, table.rows, state.filters);
   const sorted = sortRows(filtered, state.sort, state.desc);
   const maxOffset = Math.max(
     0,
@@ -225,7 +272,8 @@ function render() {
 
   tableSelect.value = state.table;
   limitSelect.value = String(state.limit);
-  renderFilterControls(table.columns);
+  saveLastTable(state.table);
+  renderFilterControls(filterColumns);
   renderSavedViews();
   scheduleChart(state.table, sorted);
   pageSummary.textContent = `${table.label}: ${start}-${end} of ${sorted.length}`;
@@ -235,13 +283,14 @@ function render() {
   activeColumns = table.columns;
   activePageRows = pageRows;
   activeTotalRows = sorted.length;
-  if (pendingScrollTop !== null) {
-    tableScroll.scrollTop = pendingScrollTop;
-    pendingScrollTop = null;
-  }
 
   tableHead.replaceChildren(renderHeader(table.columns));
   renderVirtualRows(tableBody, table.columns, pageRows, tableScroll);
+  if (pendingScrollTop !== null) {
+    tableScroll.scrollTop = pendingScrollTop;
+    pendingScrollTop = null;
+    renderVirtualRows(tableBody, table.columns, pageRows, tableScroll);
+  }
   rowDetails.replaceChildren(renderDetails(selectedRow));
 }
 
@@ -409,14 +458,108 @@ function renderDetails(row: Row | null): HTMLElement {
 
   const heading = document.createElement('h2');
   heading.textContent = row.name;
+  const relatedLinks = renderDrillThroughLinks(getDrillThroughLinks(state.table, row));
   const pre = document.createElement('pre');
   pre.textContent = JSON.stringify(row, null, 2);
-  wrapper.append(heading, pre);
+  wrapper.append(heading);
+  if (relatedLinks) wrapper.append(relatedLinks);
+  wrapper.append(pre);
   return wrapper;
 }
 
-function filterRows(rows: Row[], query: string): Row[] {
-  const filters = parseFilters(query, TABLES[state.table].columns);
+function renderDrillThroughLinks(links: DrillThroughLink[]): HTMLElement | null {
+  if (links.length === 0) return null;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'related-links';
+
+  for (const link of links) {
+    const button = document.createElement('button');
+    const count = countRowsForLink(link);
+    button.type = 'button';
+    button.className = 'related-chip';
+    button.textContent = `${link.label} ${count}`;
+    button.addEventListener('click', () => navigateDrillThrough(link));
+    wrapper.append(button);
+  }
+
+  return wrapper;
+}
+
+function getDrillThroughLinks(table: TableKey, row: Row): DrillThroughLink[] {
+  if (table === 'users') {
+    return [
+      {
+        filterKey: 'userId',
+        label: 'Assigned issues',
+        table: 'issues',
+        value: row.id,
+      },
+    ];
+  }
+
+  if (table === 'issues') {
+    return [
+      row.userId
+        ? {
+            filterKey: 'id',
+            label: 'Reporter',
+            table: 'users',
+            value: row.userId,
+          }
+        : null,
+      row.pluginId
+        ? {
+            filterKey: 'id',
+            label: 'Plugin',
+            table: 'plugins',
+            value: row.pluginId,
+          }
+        : null,
+      row.repo
+        ? {
+            filterKey: 'repo',
+            label: 'Repository issues',
+            table: 'issues',
+            value: row.repo,
+          }
+        : null,
+    ].filter((link): link is DrillThroughLink => link !== null);
+  }
+
+  return [
+    {
+      filterKey: 'pluginId',
+      label: 'Linked issues',
+      table: 'issues',
+      value: row.id,
+    },
+  ];
+}
+
+function countRowsForLink(link: DrillThroughLink): number {
+  const filters = serializeFilters([{ key: link.filterKey, op: 'eq', value: link.value }]);
+  return filterRowsForTable(link.table, TABLES[link.table].rows, filters).length;
+}
+
+function navigateDrillThrough(link: DrillThroughLink) {
+  const filters = serializeFilters([{ key: link.filterKey, op: 'eq', value: link.value }]);
+  const targetRows = sortRows(
+    filterRowsForTable(link.table, TABLES[link.table].rows, filters),
+    DEFAULT_STATE.sort,
+    DEFAULT_STATE.desc,
+  );
+  setState({
+    desc: DEFAULT_STATE.desc,
+    filters,
+    offset: 0,
+    rowId: targetRows[0]?.id ?? '',
+    sort: DEFAULT_STATE.sort,
+    table: link.table,
+  });
+}
+
+function filterRowsForTable(table: TableKey, rows: Row[], query: string): Row[] {
+  const filters = parseFilters(query, getFilterColumns(table));
   if (filters.length === 0) return rows;
   return rows.filter((row) =>
     filters.every((filter) => {
@@ -624,6 +767,48 @@ function loadSavedViews(): SavedView[] {
   }
 }
 
+function loadLastTable(): TableKey {
+  try {
+    return parseTable(localStorage.getItem(LAST_TABLE_KEY));
+  } catch {
+    return DEFAULT_STATE.table;
+  }
+}
+
+function saveLastTable(table: TableKey) {
+  try {
+    localStorage.setItem(LAST_TABLE_KEY, table);
+  } catch {
+    // URL state remains authoritative when storage is unavailable.
+  }
+}
+
+function loadTableScrollTop(table: TableKey): number {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(TABLE_SCROLL_KEY) ?? '{}');
+    const value = parsed?.[table];
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function saveTableScrollTop(table: TableKey, scrollTop: number) {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(TABLE_SCROLL_KEY) ?? '{}');
+    const next = typeof parsed === 'object' && parsed !== null ? parsed : {};
+    localStorage.setItem(
+      TABLE_SCROLL_KEY,
+      JSON.stringify({
+        ...next,
+        [table]: Math.max(0, Math.round(scrollTop)),
+      }),
+    );
+  } catch {
+    // Scroll persistence is a convenience layer only.
+  }
+}
+
 function exportCurrentView(format: 'csv' | 'json') {
   const table = TABLES[state.table];
   const fileBase = `os-ubq-fi-${state.table}-${state.offset + 1}-${state.offset + activePageRows.length}`;
@@ -686,7 +871,7 @@ function downloadBlob(contents: string, type: string, filename: string) {
 function makeUsers(): Row[] {
   const statuses = ['active', 'pending', 'suspended'];
   return Array.from({ length: 5000 }, (_, index) => ({
-    id: `usr_${String(index + 1).padStart(4, '0')}`,
+    id: makeRowId('usr', index + 1),
     created: makeDate(index),
     email: `user${index + 1}@ubq.fi`,
     name: `User ${index + 1}`,
@@ -698,11 +883,13 @@ function makeIssues(): Row[] {
   const repos = ['pay.ubq.fi', 'work.ubq.fi', 'os.ubq.fi', 'command-start-stop'];
   const statuses = ['priced', 'assigned', 'review', 'blocked'];
   return Array.from({ length: 5000 }, (_, index) => ({
-    id: `iss_${String(index + 1).padStart(4, '0')}`,
+    id: makeRowId('iss', index + 1),
     created: makeDate(index * 2),
     name: `Issue ${index + 1}: workflow follow-up`,
+    pluginId: makeRowId('plg', ((index * 7) % 5000) + 1),
     repo: repos[index % repos.length] ?? 'os.ubq.fi',
     status: statuses[index % statuses.length] ?? 'priced',
+    userId: makeRowId('usr', (index % 5000) + 1),
   }));
 }
 
@@ -710,13 +897,17 @@ function makePlugins(): Row[] {
   const owners = ['ubiquity-os-marketplace', 'ubiquity', '0x4007'];
   const health = ['healthy', 'warning', 'failing'];
   return Array.from({ length: 5000 }, (_, index) => ({
-    id: `plg_${String(index + 1).padStart(4, '0')}`,
+    id: makeRowId('plg', index + 1),
     created: makeDate(index * 3),
     health: health[index % health.length] ?? 'healthy',
     name: `Plugin ${index + 1}`,
     owner: owners[index % owners.length] ?? 'ubiquity-os-marketplace',
     status: 'monitored',
   }));
+}
+
+function makeRowId(prefix: 'iss' | 'plg' | 'usr', index: number): string {
+  return `${prefix}_${String(index).padStart(4, '0')}`;
 }
 
 function makeDate(offset: number): string {
@@ -760,16 +951,13 @@ window.addEventListener('DOMContentLoaded', () => {
 
   addFilter.addEventListener('click', () => {
     const value = filterInput.value.trim();
-    const table = TABLES[state.table];
-    const key = parseColumn(filterColumn.value, table.columns);
+    const columns = getFilterColumns(state.table);
+    const key = parseColumn(filterColumn.value, columns);
     const op = isFilterOperator(filterOperator.value) ? filterOperator.value : 'ilike';
     if (!value) return;
 
     setState({
-      filters: serializeFilters([
-        ...parseFilters(state.filters, table.columns),
-        { key, op, value },
-      ]),
+      filters: serializeFilters([...parseFilters(state.filters, columns), { key, op, value }]),
       offset: 0,
       rowId: '',
     });
@@ -830,6 +1018,7 @@ window.addEventListener('DOMContentLoaded', () => {
     if (scrollFrame) return;
     scrollFrame = requestAnimationFrame(() => {
       scrollFrame = 0;
+      saveTableScrollTop(state.table, tableScroll.scrollTop);
       renderVirtualRows(
         byId<HTMLTableSectionElement>('tableBody'),
         activeColumns,
@@ -839,6 +1028,7 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   });
 
+  pendingScrollTop = loadTableScrollTop(state.table);
   render();
   updateUrl('replace');
 });

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -26,6 +26,11 @@ type ColumnFilter = {
   value: string;
 };
 
+type SavedView = {
+  name: string;
+  search: string;
+};
+
 type ViewState = {
   desc: boolean;
   filters: string;
@@ -86,6 +91,7 @@ const FILTER_OPERATORS: Record<FilterOperator, string> = {
   eq: 'equals',
   ilike: 'contains',
 };
+const SAVED_VIEWS_KEY = 'os.ubq.fi.savedViews';
 
 let state = parseStateFromUrl(location.search);
 let activeColumns: Column[] = [];
@@ -218,6 +224,7 @@ function render() {
   tableSelect.value = state.table;
   limitSelect.value = String(state.limit);
   renderFilterControls(table.columns);
+  renderSavedViews();
   pageSummary.textContent = `${table.label}: ${start}-${end} of ${sorted.length}`;
   prevPage.disabled = offset === 0;
   nextPage.disabled = offset + state.limit >= sorted.length;
@@ -459,6 +466,81 @@ function isFilterOperator(value: string | undefined): value is FilterOperator {
   return value === 'eq' || value === 'ilike';
 }
 
+function renderSavedViews() {
+  const savedViewSelect = byId<HTMLSelectElement>('savedViewSelect');
+  const applySavedView = byId<HTMLButtonElement>('applySavedView');
+  const deleteSavedView = byId<HTMLButtonElement>('deleteSavedView');
+  const selectedName = savedViewSelect.value;
+  const savedViews = loadSavedViews();
+  savedViewSelect.replaceChildren(
+    ...savedViews.map((view) => {
+      const option = document.createElement('option');
+      option.value = view.name;
+      option.textContent = view.name;
+      return option;
+    }),
+  );
+  if (savedViews.some((view) => view.name === selectedName)) {
+    savedViewSelect.value = selectedName;
+  }
+  const hasViews = savedViews.length > 0;
+  savedViewSelect.disabled = !hasViews;
+  applySavedView.disabled = !hasViews;
+  deleteSavedView.disabled = !hasViews;
+}
+
+function saveCurrentView(name: string) {
+  const normalizedName = name.trim();
+  if (!normalizedName) return;
+  const savedViews = loadSavedViews().filter((view) => view.name !== normalizedName);
+  savedViews.push({
+    name: normalizedName,
+    search: `?${serializeState(state).toString()}`,
+  });
+  savedViews.sort((left, right) => left.name.localeCompare(right.name));
+  localStorage.setItem(SAVED_VIEWS_KEY, JSON.stringify(savedViews));
+  renderSavedViews();
+}
+
+function applySavedView(name: string) {
+  const savedView = loadSavedViews().find((view) => view.name === name);
+  if (!savedView) return;
+  pendingScrollTop = 0;
+  state = parseStateFromUrl(savedView.search);
+  render();
+  updateUrl('push');
+}
+
+function deleteSavedView(name: string) {
+  const savedViews = loadSavedViews().filter((view) => view.name !== name);
+  localStorage.setItem(SAVED_VIEWS_KEY, JSON.stringify(savedViews));
+  renderSavedViews();
+}
+
+function loadSavedViews(): SavedView[] {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(SAVED_VIEWS_KEY) ?? '[]');
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((view) => {
+        if (
+          typeof view?.name !== 'string' ||
+          typeof view?.search !== 'string' ||
+          !view.search.startsWith('?')
+        ) {
+          return null;
+        }
+        return {
+          name: view.name,
+          search: view.search,
+        };
+      })
+      .filter((view): view is SavedView => view !== null);
+  } catch {
+    return [];
+  }
+}
+
 function exportCurrentView(format: 'csv' | 'json') {
   const table = TABLES[state.table];
   const fileBase = `os-ubq-fi-${state.table}-${state.offset + 1}-${state.offset + activePageRows.length}`;
@@ -566,6 +648,11 @@ window.addEventListener('DOMContentLoaded', () => {
   const filterInput = byId<HTMLInputElement>('filterInput');
   const filterOperator = byId<HTMLSelectElement>('filterOperator');
   const addFilter = byId<HTMLButtonElement>('addFilter');
+  const savedViewName = byId<HTMLInputElement>('savedViewName');
+  const savedViewSelect = byId<HTMLSelectElement>('savedViewSelect');
+  const saveCurrentViewButton = byId<HTMLButtonElement>('saveCurrentView');
+  const applySavedViewButton = byId<HTMLButtonElement>('applySavedView');
+  const deleteSavedViewButton = byId<HTMLButtonElement>('deleteSavedView');
   const exportCsv = byId<HTMLButtonElement>('exportCsv');
   const exportJson = byId<HTMLButtonElement>('exportJson');
   const prevPage = byId<HTMLButtonElement>('prevPage');
@@ -610,6 +697,25 @@ window.addEventListener('DOMContentLoaded', () => {
     if (event.key !== 'Enter') return;
     event.preventDefault();
     addFilter.click();
+  });
+
+  saveCurrentViewButton.addEventListener('click', () => {
+    saveCurrentView(savedViewName.value);
+    savedViewName.value = '';
+  });
+
+  savedViewName.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    saveCurrentViewButton.click();
+  });
+
+  applySavedViewButton.addEventListener('click', () => {
+    applySavedView(savedViewSelect.value);
+  });
+
+  deleteSavedViewButton.addEventListener('click', () => {
+    deleteSavedView(savedViewSelect.value);
   });
 
   exportCsv.addEventListener('click', () => {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -137,6 +137,7 @@ const FILTER_OPERATORS: Record<FilterOperator, string> = {
   eq: 'equals',
   ilike: 'contains',
 };
+const DETAILS_REGION_ID = 'rowDetails';
 const LAST_TABLE_KEY = 'os.ubq.fi.lastTable';
 const SAVED_VIEWS_KEY = 'os.ubq.fi.savedViews';
 const TABLE_SCROLL_KEY = 'os.ubq.fi.tableScrollTop';
@@ -148,6 +149,7 @@ let activeTotalRows = 0;
 let chartFrame = 0;
 let gridStatus: 'loading' | 'ready' = 'loading';
 let pendingChart: { rows: Row[]; table: TableKey } | null = null;
+let pendingFocusRowId: string | null = null;
 let pendingScrollTop: number | null = null;
 let relationAbortController: AbortController | null = null;
 let relationState: RelationState = {
@@ -268,6 +270,7 @@ function render() {
 
   const table = TABLES[state.table];
   const filterColumns = getFilterColumns(state.table);
+  const dataGrid = byId<HTMLTableElement>('dataGrid');
   const filtered = filterRowsForTable(state.table, table.rows, state.filters);
   const sorted = sortRows(filtered, state.sort, state.desc);
   const maxOffset = Math.max(
@@ -289,6 +292,8 @@ function render() {
   tableSelect.value = state.table;
   limitSelect.value = String(state.limit);
   saveLastTable(state.table);
+  dataGrid.setAttribute('aria-rowcount', String(sorted.length));
+  dataGrid.setAttribute('aria-colcount', String(table.columns.length + 1));
   renderFilterControls(filterColumns);
   renderSavedViews();
 
@@ -373,6 +378,7 @@ function renderVirtualRows(
   rows: Row[],
   scrollEl: HTMLElement,
 ) {
+  const rowToRefocus = pendingFocusRowId ?? getFocusedRowId();
   if (rows.length === 0) {
     tableBody.replaceChildren(renderEmptyRow(columns.length + 1));
     return;
@@ -396,6 +402,10 @@ function renderVirtualRows(
     ...visibleRows,
     renderSpacerRow(bottomHeight, columns.length + 1),
   );
+  if (rowToRefocus) {
+    pendingFocusRowId = rowToRefocus;
+    requestAnimationFrame(flushPendingRowFocus);
+  }
 }
 
 function renderTableSkeletonRows(tableBody: HTMLTableSectionElement, colSpan: number) {
@@ -456,10 +466,13 @@ function renderHeader(columns: Column[]): HTMLTableRowElement {
     const th = document.createElement('th');
     const button = document.createElement('button');
     const isActive = state.sort === column.key;
+    const nextDirection = isActive && !state.desc ? 'descending' : 'ascending';
+    th.scope = 'col';
+    th.setAttribute('aria-sort', isActive ? (state.desc ? 'descending' : 'ascending') : 'none');
     button.type = 'button';
     button.className = 'sort-button';
     button.textContent = `${column.label}${isActive ? (state.desc ? ' ↓' : ' ↑') : ''}`;
-    button.setAttribute('aria-sort', isActive ? (state.desc ? 'descending' : 'ascending') : 'none');
+    button.setAttribute('aria-label', `Sort ${column.label} ${nextDirection}`);
     button.addEventListener('click', () => {
       setState({
         desc: isActive ? !state.desc : false,
@@ -472,6 +485,7 @@ function renderHeader(columns: Column[]): HTMLTableRowElement {
   }
 
   const th = document.createElement('th');
+  th.scope = 'col';
   th.textContent = 'Details';
   tr.append(th);
   return tr;
@@ -479,8 +493,14 @@ function renderHeader(columns: Column[]): HTMLTableRowElement {
 
 function renderRow(row: Row, columns: Column[]): HTMLTableRowElement {
   const tr = document.createElement('tr');
+  const isSelected = row.id === state.rowId;
   tr.dataset.rowId = row.id;
-  if (row.id === state.rowId) {
+  tr.tabIndex = 0;
+  tr.setAttribute('aria-controls', DETAILS_REGION_ID);
+  tr.setAttribute('aria-label', getRowAriaLabel(row, isSelected));
+  tr.setAttribute('aria-selected', String(isSelected));
+  tr.addEventListener('keydown', (event) => handleRowKeydown(event, row.id));
+  if (isSelected) {
     tr.classList.add('selected-row');
   }
 
@@ -494,14 +514,110 @@ function renderRow(row: Row, columns: Column[]): HTMLTableRowElement {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'row-toggle';
-  button.textContent = row.id === state.rowId ? 'Close' : 'Open';
-  button.setAttribute('aria-expanded', String(row.id === state.rowId));
+  button.textContent = isSelected ? 'Close' : 'Open';
+  button.setAttribute('aria-controls', DETAILS_REGION_ID);
+  button.setAttribute('aria-expanded', String(isSelected));
+  button.setAttribute('aria-label', `${isSelected ? 'Close' : 'Open'} details for ${row.name}`);
   button.addEventListener('click', () => {
-    setState({ rowId: state.rowId === row.id ? '' : row.id });
+    toggleRowDetails(row.id);
   });
   action.append(button);
   tr.append(action);
   return tr;
+}
+
+function getRowAriaLabel(row: Row, isSelected: boolean): string {
+  const detailsState = isSelected ? 'Details are open.' : 'Details are closed.';
+  return `${row.name}, ${row.status}, ${row.id}. ${detailsState} Press Enter to ${
+    isSelected ? 'close' : 'open'
+  } details.`;
+}
+
+function handleRowKeydown(event: KeyboardEvent, rowId: string) {
+  if (event.target !== event.currentTarget) return;
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    toggleRowDetails(rowId);
+    return;
+  }
+
+  if (
+    event.key === 'ArrowDown' ||
+    event.key === 'ArrowUp' ||
+    event.key === 'End' ||
+    event.key === 'Home'
+  ) {
+    event.preventDefault();
+    moveRowFocus(rowId, event.key);
+  }
+}
+
+function toggleRowDetails(rowId: string) {
+  pendingFocusRowId = rowId;
+  setState({ rowId: state.rowId === rowId ? '' : rowId });
+}
+
+function moveRowFocus(rowId: string, key: 'ArrowDown' | 'ArrowUp' | 'End' | 'Home') {
+  const currentIndex = activePageRows.findIndex((row) => row.id === rowId);
+  if (currentIndex < 0 || activePageRows.length === 0) return;
+
+  const targetIndex =
+    key === 'Home'
+      ? 0
+      : key === 'End'
+        ? activePageRows.length - 1
+        : key === 'ArrowDown'
+          ? Math.min(activePageRows.length - 1, currentIndex + 1)
+          : Math.max(0, currentIndex - 1);
+  const target = activePageRows[targetIndex];
+  if (!target) return;
+
+  const tableScroll = byId<HTMLDivElement>('tableScroll');
+  pendingFocusRowId = target.id;
+  ensurePageRowVisible(targetIndex, tableScroll);
+  renderVirtualRows(
+    byId<HTMLTableSectionElement>('tableBody'),
+    activeColumns,
+    activePageRows,
+    tableScroll,
+  );
+}
+
+function ensurePageRowVisible(index: number, scrollEl: HTMLElement) {
+  const rowTop = index * ROW_HEIGHT;
+  const rowBottom = rowTop + ROW_HEIGHT;
+  const viewportTop = scrollEl.scrollTop;
+  const viewportBottom = viewportTop + scrollEl.clientHeight;
+
+  if (rowTop < viewportTop) {
+    scrollEl.scrollTop = rowTop;
+  } else if (rowBottom > viewportBottom) {
+    scrollEl.scrollTop = Math.max(0, rowBottom - scrollEl.clientHeight);
+  }
+}
+
+function flushPendingRowFocus() {
+  if (!pendingFocusRowId) return;
+  const row = getRenderedRowElement(pendingFocusRowId);
+  if (!row) return;
+  row.focus({ preventScroll: true });
+  row.scrollIntoView({ block: 'nearest' });
+  pendingFocusRowId = null;
+}
+
+function getRenderedRowElement(rowId: string): HTMLTableRowElement | null {
+  return (
+    [...document.querySelectorAll<HTMLTableRowElement>('tbody tr[data-row-id]')].find(
+      (row) => row.dataset.rowId === rowId,
+    ) ?? null
+  );
+}
+
+function getFocusedRowId(): string | null {
+  if (!(document.activeElement instanceof HTMLElement)) return null;
+  if (document.activeElement.tagName !== 'TR') return null;
+  return document.activeElement.dataset.rowId ?? null;
 }
 
 function renderDetails(row: Row | null): HTMLElement {
@@ -525,6 +641,8 @@ function renderDetails(row: Row | null): HTMLElement {
   const relatedLinks =
     relations.status === 'loading' ? null : renderDrillThroughLinks(relations.links);
   const pre = document.createElement('pre');
+  pre.tabIndex = 0;
+  pre.setAttribute('aria-label', `JSON payload for ${row.name}`);
   pre.textContent = JSON.stringify(row, null, 2);
   wrapper.append(heading);
   if (relations.status === 'loading') {
@@ -687,6 +805,7 @@ function renderDrillThroughLinks(links: DrillThroughLink[]): HTMLElement | null 
   if (links.length === 0) return null;
   const wrapper = document.createElement('div');
   wrapper.className = 'related-links';
+  wrapper.setAttribute('aria-label', 'Related rows');
 
   for (const link of links) {
     const button = document.createElement('button');
@@ -694,6 +813,7 @@ function renderDrillThroughLinks(links: DrillThroughLink[]): HTMLElement | null 
     button.type = 'button';
     button.className = 'related-chip';
     button.textContent = `${link.label} ${count}`;
+    button.setAttribute('aria-label', `${link.label}: ${count} matching rows`);
     button.addEventListener('click', () => navigateDrillThrough(link));
     wrapper.append(button);
   }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -97,6 +97,8 @@ let state = parseStateFromUrl(location.search);
 let activeColumns: Column[] = [];
 let activePageRows: Row[] = [];
 let activeTotalRows = 0;
+let chartFrame = 0;
+let pendingChart: { rows: Row[]; table: TableKey } | null = null;
 let pendingScrollTop: number | null = null;
 let scrollFrame = 0;
 
@@ -225,6 +227,7 @@ function render() {
   limitSelect.value = String(state.limit);
   renderFilterControls(table.columns);
   renderSavedViews();
+  scheduleChart(state.table, sorted);
   pageSummary.textContent = `${table.label}: ${start}-${end} of ${sorted.length}`;
   prevPage.disabled = offset === 0;
   nextPage.disabled = offset + state.limit >= sorted.length;
@@ -464,6 +467,86 @@ function serializeFilters(filters: ColumnFilter[]): string {
 
 function isFilterOperator(value: string | undefined): value is FilterOperator {
   return value === 'eq' || value === 'ilike';
+}
+
+function scheduleChart(table: TableKey, rows: Row[]) {
+  pendingChart = { rows, table };
+  if (chartFrame) return;
+  chartFrame = requestAnimationFrame(() => {
+    chartFrame = 0;
+    if (!pendingChart) return;
+    renderChart(pendingChart.table, pendingChart.rows);
+    pendingChart = null;
+  });
+}
+
+function renderChart(table: TableKey, rows: Row[]) {
+  const chartPanel = byId<HTMLElement>('chartPanel');
+  const chartKey: keyof Row = table === 'plugins' ? 'health' : 'status';
+  const title = chartKey === 'health' ? 'Health totals' : 'Status totals';
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const value = String(row[chartKey] ?? 'unknown');
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  const entries = [...counts.entries()].sort((left, right) => {
+    const byCount = right[1] - left[1];
+    return byCount || left[0].localeCompare(right[0]);
+  });
+
+  const heading = document.createElement('h2');
+  heading.className = 'chart-title';
+  heading.textContent = `${title} from ${rows.length} current rows`;
+
+  if (entries.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'chart-empty';
+    empty.textContent = 'No rows to chart';
+    chartPanel.replaceChildren(heading, empty);
+    return;
+  }
+
+  const maxCount = Math.max(...entries.map(([, count]) => count));
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  const width = 640;
+  const rowHeight = 32;
+  const height = entries.length * rowHeight + 18;
+  svg.classList.add('chart-svg');
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', `${title} chart`);
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+  entries.forEach(([label, count], index) => {
+    const y = index * rowHeight + 8;
+    const barWidth = Math.max(2, Math.round((count / maxCount) * 360));
+    const text = `${label} ${count}`;
+
+    const labelNode = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    labelNode.setAttribute('x', '0');
+    labelNode.setAttribute('y', String(y + 17));
+    labelNode.textContent = label;
+
+    const bar = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    bar.setAttribute('x', '150');
+    bar.setAttribute('y', String(y));
+    bar.setAttribute('width', String(barWidth));
+    bar.setAttribute('height', '20');
+    bar.setAttribute('rx', '3');
+
+    const countNode = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    countNode.setAttribute('x', String(160 + barWidth));
+    countNode.setAttribute('y', String(y + 16));
+    countNode.textContent = String(count);
+
+    const titleNode = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+    titleNode.textContent = text;
+
+    const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    group.append(titleNode, labelNode, bar, countNode);
+    svg.append(group);
+  });
+
+  chartPanel.replaceChildren(heading, svg);
 }
 
 function renderSavedViews() {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -32,6 +32,47 @@ Deno.test('POST /api/echo returns same JSON', async () => {
   assertEquals(data.echoed.hello, 'world');
 });
 
+Deno.test('GET /api/sb/relations returns exact issue edges', async () => {
+  const res = await handler(
+    new Request('http://localhost/api/sb/relations?table=issues&id=iss_0002'),
+  );
+  assertEquals(res.status, 200);
+  const data = await res.json();
+  assertEquals(data.source, 'exact-fk-rpc');
+  assertEquals(data.edges, [
+    {
+      filterKey: 'id',
+      label: 'Reporter',
+      table: 'users',
+      value: 'usr_0002',
+    },
+    {
+      filterKey: 'id',
+      label: 'Plugin',
+      table: 'plugins',
+      value: 'plg_0008',
+    },
+    {
+      filterKey: 'repo',
+      label: 'Repository issues',
+      table: 'issues',
+      value: 'work.ubq.fi',
+    },
+  ]);
+});
+
+Deno.test('GET /api/sb/relations validates query params', async () => {
+  const badTable = await handler(
+    new Request('http://localhost/api/sb/relations?table=unknown&id=iss_0001'),
+  );
+  assertEquals(badTable.status, 400);
+
+  const badId = await handler(
+    new Request('http://localhost/api/sb/relations?table=issues&id=missing'),
+  );
+  assertEquals(badId.status, 404);
+});
+
 Deno.test('GET / serves index.html', async () => {
   const res = await handler(new Request('http://localhost/'));
   assertEquals(res.status, 200);


### PR DESCRIPTION
Fixes #1
Fixes #2
Fixes #3
Fixes #4
Fixes #5
Fixes #6
Fixes #8
Fixes #9
Fixes #10
Fixes #11
Fixes #12
Fixes #14
Fixes #15
Fixes #16
Fixes #17
Fixes #19
Fixes #20
Fixes #21
Fixes #22

## Proposed changes
- Replace the minimal sample page with an operational table browser for users, issues, and plugins.
- Sync table, offset, limit, sort, desc, filters, and rowId into URL state with back/forward restoration.
- Add loading skeleton rows, inspector skeletons, muted empty states, and inline relation error banners.
- Add `/api/sb/relations` for exact issue/user/plugin relation edges, with validated bad table/id responses.
- Prefer exact relation edges from `/api/sb/relations` in the inspector and fall back to generated FK links when the RPC is unavailable.
- Add saved views backed by `localStorage` so users can name, apply, and delete the current URL state.
- Add clickable sortable headers with asc/desc indicators.
- Add per-column filters with `equals` and `contains` operators, removable chips, and URL persistence, including hidden FK filters for drill-through links.
- Add row deep links, an expanded row details inspector, and related chips that navigate to target tables with exact FK filters and select the first matching row.
- Persist `lastTable` and per-table scrollTop in `localStorage` so returning without a table parameter restores the previous table surface.
- Add a lazy-rendered SVG chart panel for current filtered-row totals without extra requests.
- Add 5000-row table mode with virtualized rendering, spacer rows, and selection/details persistence while scrolling.
- Add CSV and JSON export buttons for the current sorted, filtered, paginated slice.
- Add first-paint skeleton rows and consistent hover/pressed states across controls, chips, and rows.
- Add print/PDF styling that hides interactive chrome, expands the table, wraps cells, and keeps the inspector readable.
- Add spacing, typography, radius, semantic color, focus, skeleton, shadow, and transition CSS tokens.
- Refactor dashboard CSS to use the token layer across panels, controls, tables, chips, skeletons, print styles, and row focus.
- Add a persisted light/dark theme toggle backed by `localStorage`, with pre-CSS root theme restoration on reload.
- Add accessible grid semantics: named controls, `aria-sort` on sortable headers, row/detail control relationships, visible row focus, and a named details region.
- Add keyboard row navigation: Tab reaches rows and row actions, Arrow Up/Down/Home/End moves within the current page, and Enter/Space opens or closes row details while preserving focus across virtualized and relation-fetch re-renders.
- Document URL parameters, state surfaces, exact relation lookup/fallback behavior, saved views, drill-through behavior, filters, charts, row deep links, theme persistence, large-page behavior, exports, print output, and keyboard behavior in docs/UI.md.

## Proof
- `deno run -A npm:prettier@^3 --check src/web/app.ts src/server.ts tests/server.test.ts public/index.html public/styles.css docs/UI.md`
- `deno check src/web/app.ts src/server.ts tests/server.test.ts`
- `deno task lint`
- `deno task test` (6 tests, including `/api/sb/relations` exact-edge and validation coverage)
- `deno task build`
- `git diff --check`
- Browser verified deep link restoration at `/?table=users&offset=50&limit=25&sort=created&desc=true`.
- Browser verified saved views persist in the saved list, restore URL/table/filter state when applied, and disable controls after deletion.
- Browser verified filter deep link restoration at `/?table=issues&offset=0&limit=25&sort=created&desc=false&filters=repo.ilike.work,status.eq.assigned`.
- Browser verified adding and removing a filter chip updates the URL and rows.
- Browser verified `rowId=iss_0026` selects the row and opens the details panel on load.
- Browser verified `/api/sb/relations?table=issues&id=iss_0002` returns exact edges for `Reporter:users.id.usr_0002`, `Plugin:plugins.id.plg_0008`, and `Repository issues:issues.repo.work.ubq.fi`.
- Browser verified issue detail chips navigate from exact/fallback relation labels to the expected filtered tables.
- Browser verified a no-match filter shows muted empty messaging: `No matching rows` and `Clear filters or broaden the current search.`
- Browser verified a forced relation RPC `503` shows an inline error banner while preserving fallback related chips.
- Browser verified back navigation returns from a linked-issues drill-through to the prior plugin detail state.
- Browser verified returning without a `table` parameter restores `lastTable=plugins` and the saved table scrollTop of `550`.
- Browser verified chart totals: filtered issues chart showed one `assigned` bucket with 1,250 rows, and plugins chart showed health totals summing to 5,000.
- Browser verified `limit=5000` renders only about 20 data rows while preserving smooth scrolling and details state.
- Browser verified CSV and JSON Blob payloads for `?table=issues&offset=25&limit=10&sort=created&desc=false` match issues 26-35.
- Browser verified theme behavior at `/?table=issues&limit=25`: light mode shows `data-theme=light`, the toggle switches to dark with `aria-pressed=true`, dark mode persists after reload, and the toggle returns to light with the correct accessible label.
- Browser verified accessibility/keyboard behavior at `/?table=issues&limit=25`: focusing the first row and pressing Enter opened `rowId=iss_0001` while focus stayed on the row; ArrowDown moved focus to `iss_0002`; Enter opened `iss_0002` and updated URL/`aria-selected`; Tab moved to the row's Close button with an accessible label.
- Browser accessibility smoke check passed: buttons had names, form fields had labels, the table exposed grid role plus row/column counts, rows were focusable and controlled the details region, sortable headers exposed `aria-sort`, and the details region had a role and accessible name.

Note: `deno` is not installed globally in my local environment, so I used temporary npm Deno 2.7.14 for the verification commands above.
