### PR TITLE
Add print stylesheet

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -6,29 +6,84 @@
   --muted: #9aa4af;
 }
 
-* { box-sizing: border-box; }
-html, body { height: 100%; margin: 0; }
+* {
+  box-sizing: border-box;
+}
+html,
 body {
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  height: 100%;
+  margin: 0;
+}
+body {
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Inter,
+    Helvetica,
+    Arial,
+    "Apple Color Emoji",
+    "Segoe UI Emoji";
   line-height: 1.5;
   background: var(--bg);
   color: var(--fg);
 }
-main { max-width: 720px; margin: 3rem auto; padding: 0 1rem; }
-h1 { font-size: 1.6rem; margin: 0 0 1rem; }
-h2 { font-size: 1.2rem; margin: 2rem 0 0.5rem; }
-section { padding: 1rem; border: 1px solid #222; border-radius: 8px; }
+main {
+  max-width: 720px;
+  margin: 3rem auto;
+  padding: 0 1rem;
+}
+h1 {
+  font-size: 1.6rem;
+  margin: 0 0 1rem;
+}
+h2 {
+  font-size: 1.2rem;
+  margin: 2rem 0 0.5rem;
+}
+section {
+  padding: 1rem;
+  border: 1px solid #222;
+  border-radius: 8px;
+}
 button {
-  background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer;
-  padding: 0.5rem 0.75rem; font-weight: 600; letter-spacing: 0.2px;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 0.5rem 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.2px;
 }
-button:hover { filter: brightness(1.05); }
+button:hover {
+  filter: brightness(1.05);
+}
 pre {
-  background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
-  overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
+  background: #0f1115;
+  border: 1px solid #1b1f2a;
+  padding: 0.75rem;
+  border-radius: 6px;
+  overflow: auto;
+  max-height: 240px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
-textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
-label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
+textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #333;
+  color: inherit;
+  background: transparent;
+}
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--muted);
+}
 
 @media print {
   :root {

--- a/public/styles.css
+++ b/public/styles.css
@@ -30,3 +30,62 @@ pre {
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+@media print {
+  :root {
+    --bg: #fff;
+    --fg: #111;
+    --muted: #444;
+  }
+
+  html,
+  body {
+    height: auto;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-size: 11pt;
+  }
+
+  main {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  button,
+  form,
+  textarea,
+  label {
+    display: none !important;
+  }
+
+  section {
+    break-inside: avoid;
+    border: 0;
+    border-radius: 0;
+    border-top: 1px solid #999;
+    margin: 0 0 1rem;
+    padding: 0.75rem 0 0;
+  }
+
+  h1,
+  h2 {
+    break-after: avoid;
+    color: #000;
+  }
+
+  pre {
+    break-inside: avoid;
+    max-height: none;
+    overflow: visible;
+    white-space: pre-wrap;
+    word-break: break-word;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    color: #111;
+    padding: 0;
+  }
+}

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -1,0 +1,20 @@
+import { assert, assertStringIncludes } from "@std/assert";
+
+const stylesheet = await Deno.readTextFile(
+  new URL("../public/styles.css", import.meta.url),
+);
+
+Deno.test("print stylesheet hides interactive chrome", () => {
+  assertStringIncludes(stylesheet, "@media print");
+  assertStringIncludes(stylesheet, "button,");
+  assertStringIncludes(stylesheet, "form,");
+  assertStringIncludes(stylesheet, "textarea,");
+  assertStringIncludes(stylesheet, "display: none !important;");
+});
+
+Deno.test("print stylesheet keeps output legible", () => {
+  assertStringIncludes(stylesheet, "max-height: none;");
+  assertStringIncludes(stylesheet, "overflow: visible;");
+  assertStringIncludes(stylesheet, "word-break: break-word;");
+  assert(stylesheet.includes("break-inside: avoid"));
+});


### PR DESCRIPTION
Closes #16.

## Summary
- Adds print-specific CSS in `public/styles.css`.
- Uses a white print surface, removes interactive controls, expands result blocks, and avoids breaking sections/preformatted output across pages.
- Keeps the on-screen layout unchanged.

## Validation
- `npx --yes deno@2.7.14 test -A tests/styles.test.ts`
- `npx --yes prettier@^3 --check public/styles.css tests/styles.test.ts`
- `git diff --check`

`deno` is not available in this local shell, so the focused stylesheet test was run through temporary npm Deno 2.7.14.

## Bounty
Preferred payout: 75 USD / USDT on Polygon PoS to `0xE7201960FEa5bFF7Ae4Fe3286093dCedabeDB003`.

/claim #16

