### PR TITLE
Add loading empty and error states

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,13 +14,13 @@
       <section>
         <h2>Health</h2>
         <button id="checkHealth">Check Health</button>
-        <pre id="healthOut">(click to load)</pre>
+        <pre id="healthOut" class="output-empty">No health status loaded yet.</pre>
       </section>
 
       <section>
         <h2>Time</h2>
         <button id="getTime">Get Time</button>
-        <pre id="timeOut">(click to load)</pre>
+        <pre id="timeOut" class="output-empty">No server time loaded yet.</pre>
       </section>
 
       <section>
@@ -32,7 +32,7 @@
           </label>
           <button type="submit">POST /api/echo</button>
         </form>
-        <pre id="echoOut">(submit to send)</pre>
+        <pre id="echoOut" class="output-empty">No echo response submitted yet.</pre>
       </section>
     </main>
 

--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,9 @@
       <section>
         <h2>Health</h2>
         <button id="checkHealth">Check Health</button>
-        <pre id="healthOut" class="output-empty">No health status loaded yet.</pre>
+        <pre id="healthOut" class="output-empty">
+No health status loaded yet.</pre
+        >
       </section>
 
       <section>
@@ -28,14 +30,20 @@
         <form id="echoForm">
           <label>
             JSON payload
-            <textarea id="echoInput" rows="4" placeholder='{"hello":"world"}'></textarea>
+            <textarea
+              id="echoInput"
+              rows="4"
+              placeholder='{"hello":"world"}'
+            ></textarea>
           </label>
           <button type="submit">POST /api/echo</button>
         </form>
-        <pre id="echoOut" class="output-empty">No echo response submitted yet.</pre>
+        <pre id="echoOut" class="output-empty">
+No echo response submitted yet.</pre
+        >
       </section>
     </main>
 
     <script type="module" defer src="/assets/app.js"></script>
   </body>
-  </html>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -30,3 +30,47 @@ pre {
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+.output-empty {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.output-error {
+  background: #2a1215;
+  border-color: #9f3942;
+  color: #ffd8dc;
+}
+
+.output-loading {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.skeleton-line {
+  display: block;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #1b1f2a 25%, #2c3442 37%, #1b1f2a 63%);
+  background-size: 400% 100%;
+  animation: skeleton-pulse 1.25s ease-in-out infinite;
+}
+
+.skeleton-line--short {
+  width: 45%;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes skeleton-pulse {
+  0% { background-position: 100% 50%; }
+  100% { background-position: 0 50%; }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -6,29 +6,84 @@
   --muted: #9aa4af;
 }
 
-* { box-sizing: border-box; }
-html, body { height: 100%; margin: 0; }
+* {
+  box-sizing: border-box;
+}
+html,
 body {
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  height: 100%;
+  margin: 0;
+}
+body {
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Inter,
+    Helvetica,
+    Arial,
+    "Apple Color Emoji",
+    "Segoe UI Emoji";
   line-height: 1.5;
   background: var(--bg);
   color: var(--fg);
 }
-main { max-width: 720px; margin: 3rem auto; padding: 0 1rem; }
-h1 { font-size: 1.6rem; margin: 0 0 1rem; }
-h2 { font-size: 1.2rem; margin: 2rem 0 0.5rem; }
-section { padding: 1rem; border: 1px solid #222; border-radius: 8px; }
+main {
+  max-width: 720px;
+  margin: 3rem auto;
+  padding: 0 1rem;
+}
+h1 {
+  font-size: 1.6rem;
+  margin: 0 0 1rem;
+}
+h2 {
+  font-size: 1.2rem;
+  margin: 2rem 0 0.5rem;
+}
+section {
+  padding: 1rem;
+  border: 1px solid #222;
+  border-radius: 8px;
+}
 button {
-  background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer;
-  padding: 0.5rem 0.75rem; font-weight: 600; letter-spacing: 0.2px;
+  background: #1a73e8;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 0.5rem 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.2px;
 }
-button:hover { filter: brightness(1.05); }
+button:hover {
+  filter: brightness(1.05);
+}
 pre {
-  background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
-  overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
+  background: #0f1115;
+  border: 1px solid #1b1f2a;
+  padding: 0.75rem;
+  border-radius: 6px;
+  overflow: auto;
+  max-height: 240px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
-textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
-label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
+textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #333;
+  color: inherit;
+  background: transparent;
+}
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--muted);
+}
 
 .output-empty {
   color: var(--muted);
@@ -71,6 +126,10 @@ label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 }
 
 @keyframes skeleton-pulse {
-  0% { background-position: 100% 50%; }
-  100% { background-position: 0 50%; }
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
 }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,6 +1,9 @@
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
 
-async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
+async function fetchJSON(
+  path: string,
+  options: RequestInit = {},
+): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
   const text = await res.text();
   let data: unknown = text;
@@ -12,35 +15,46 @@ async function fetchJSON(path: string, options: RequestInit = {}): Promise<Fetch
   return { ok: res.ok, status: res.status, data };
 }
 
-function setOutputState(el: HTMLElement, state: 'empty' | 'error' | 'loading' | 'ready') {
-  el.classList.remove('output-empty', 'output-error', 'output-loading', 'output-ready');
+function setOutputState(
+  el: HTMLElement,
+  state: "empty" | "error" | "loading" | "ready",
+) {
+  el.classList.remove(
+    "output-empty",
+    "output-error",
+    "output-loading",
+    "output-ready",
+  );
   el.classList.add(`output-${state}`);
 }
 
 function isEmptyData(value: unknown) {
-  if (value == null || value === '') return true;
+  if (value == null || value === "") return true;
   if (Array.isArray(value)) return value.length === 0;
-  if (typeof value === 'object') return Object.keys(value).length === 0;
+  if (typeof value === "object") return Object.keys(value).length === 0;
   return false;
 }
 
 function show(el: HTMLElement, value: unknown) {
-  setOutputState(el, 'ready');
-  el.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  setOutputState(el, "ready");
+  el.textContent =
+    typeof value === "string" ? value : JSON.stringify(value, null, 2);
 }
 
 function showEmpty(el: HTMLElement, message: string) {
-  setOutputState(el, 'empty');
+  setOutputState(el, "empty");
   el.textContent = message;
 }
 
 function showError(el: HTMLElement, message: string, details?: unknown) {
-  setOutputState(el, 'error');
-  el.textContent = details ? `${message}\n\n${JSON.stringify(details, null, 2)}` : message;
+  setOutputState(el, "error");
+  el.textContent = details
+    ? `${message}\n\n${JSON.stringify(details, null, 2)}`
+    : message;
 }
 
 function showLoading(el: HTMLElement, label: string) {
-  setOutputState(el, 'loading');
+  setOutputState(el, "loading");
   el.innerHTML = `
     <span class="skeleton-line skeleton-line--short"></span>
     <span class="skeleton-line"></span>
@@ -49,7 +63,11 @@ function showLoading(el: HTMLElement, label: string) {
   `;
 }
 
-function showResponse(el: HTMLElement, res: FetchJSONResult, emptyMessage: string) {
+function showResponse(
+  el: HTMLElement,
+  res: FetchJSONResult,
+  emptyMessage: string,
+) {
   if (!res.ok) {
     showError(el, `Request failed with status ${res.status}`, res.data);
     return;
@@ -69,55 +87,55 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-  const healthBtn = byId<HTMLButtonElement>('checkHealth');
-  const healthOut = byId<HTMLPreElement>('healthOut');
-  const timeBtn = byId<HTMLButtonElement>('getTime');
-  const timeOut = byId<HTMLPreElement>('timeOut');
-  const echoForm = byId<HTMLFormElement>('echoForm');
-  const echoInput = byId<HTMLTextAreaElement>('echoInput');
-  const echoOut = byId<HTMLPreElement>('echoOut');
+window.addEventListener("DOMContentLoaded", () => {
+  const healthBtn = byId<HTMLButtonElement>("checkHealth");
+  const healthOut = byId<HTMLPreElement>("healthOut");
+  const timeBtn = byId<HTMLButtonElement>("getTime");
+  const timeOut = byId<HTMLPreElement>("timeOut");
+  const echoForm = byId<HTMLFormElement>("echoForm");
+  const echoInput = byId<HTMLTextAreaElement>("echoInput");
+  const echoOut = byId<HTMLPreElement>("echoOut");
 
-  healthBtn.addEventListener('click', async () => {
-    showLoading(healthOut, 'Loading health status');
+  healthBtn.addEventListener("click", async () => {
+    showLoading(healthOut, "Loading health status");
     try {
-      const res = await fetchJSON('/api/health');
-      showResponse(healthOut, res, 'No health status returned.');
+      const res = await fetchJSON("/api/health");
+      showResponse(healthOut, res, "No health status returned.");
     } catch (err) {
-      showError(healthOut, 'Unable to load health status.', String(err));
+      showError(healthOut, "Unable to load health status.", String(err));
     }
   });
 
-  timeBtn.addEventListener('click', async () => {
-    showLoading(timeOut, 'Loading server time');
+  timeBtn.addEventListener("click", async () => {
+    showLoading(timeOut, "Loading server time");
     try {
-      const res = await fetchJSON('/api/time');
-      showResponse(timeOut, res, 'No time data returned.');
+      const res = await fetchJSON("/api/time");
+      showResponse(timeOut, res, "No time data returned.");
     } catch (err) {
-      showError(timeOut, 'Unable to load server time.', String(err));
+      showError(timeOut, "Unable to load server time.", String(err));
     }
   });
 
-  echoForm.addEventListener('submit', async (e) => {
+  echoForm.addEventListener("submit", async (e) => {
     e.preventDefault();
-    const bodyText = echoInput.value || '{}';
+    const bodyText = echoInput.value || "{}";
     try {
       JSON.parse(bodyText);
     } catch (err) {
-      showError(echoOut, 'Invalid JSON payload.', String(err));
+      showError(echoOut, "Invalid JSON payload.", String(err));
       return;
     }
 
-    showLoading(echoOut, 'Sending echo request');
+    showLoading(echoOut, "Sending echo request");
     try {
-      const res = await fetchJSON('/api/echo', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
+      const res = await fetchJSON("/api/echo", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
         body: bodyText,
       });
-      showResponse(echoOut, res, 'No echo payload returned.');
+      showResponse(echoOut, res, "No echo payload returned.");
     } catch (err) {
-      showError(echoOut, 'Unable to send echo request.', String(err));
+      showError(echoOut, "Unable to send echo request.", String(err));
     }
   });
 });

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -12,8 +12,55 @@ async function fetchJSON(path: string, options: RequestInit = {}): Promise<Fetch
   return { ok: res.ok, status: res.status, data };
 }
 
+function setOutputState(el: HTMLElement, state: 'empty' | 'error' | 'loading' | 'ready') {
+  el.classList.remove('output-empty', 'output-error', 'output-loading', 'output-ready');
+  el.classList.add(`output-${state}`);
+}
+
+function isEmptyData(value: unknown) {
+  if (value == null || value === '') return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value).length === 0;
+  return false;
+}
+
 function show(el: HTMLElement, value: unknown) {
+  setOutputState(el, 'ready');
   el.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+}
+
+function showEmpty(el: HTMLElement, message: string) {
+  setOutputState(el, 'empty');
+  el.textContent = message;
+}
+
+function showError(el: HTMLElement, message: string, details?: unknown) {
+  setOutputState(el, 'error');
+  el.textContent = details ? `${message}\n\n${JSON.stringify(details, null, 2)}` : message;
+}
+
+function showLoading(el: HTMLElement, label: string) {
+  setOutputState(el, 'loading');
+  el.innerHTML = `
+    <span class="skeleton-line skeleton-line--short"></span>
+    <span class="skeleton-line"></span>
+    <span class="skeleton-line"></span>
+    <span class="sr-only">${label}</span>
+  `;
+}
+
+function showResponse(el: HTMLElement, res: FetchJSONResult, emptyMessage: string) {
+  if (!res.ok) {
+    showError(el, `Request failed with status ${res.status}`, res.data);
+    return;
+  }
+
+  if (isEmptyData(res.data)) {
+    showEmpty(el, emptyMessage);
+    return;
+  }
+
+  show(el, res);
 }
 
 function byId<T extends HTMLElement>(id: string): T {
@@ -32,13 +79,23 @@ window.addEventListener('DOMContentLoaded', () => {
   const echoOut = byId<HTMLPreElement>('echoOut');
 
   healthBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/health');
-    show(healthOut, res);
+    showLoading(healthOut, 'Loading health status');
+    try {
+      const res = await fetchJSON('/api/health');
+      showResponse(healthOut, res, 'No health status returned.');
+    } catch (err) {
+      showError(healthOut, 'Unable to load health status.', String(err));
+    }
   });
 
   timeBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/time');
-    show(timeOut, res);
+    showLoading(timeOut, 'Loading server time');
+    try {
+      const res = await fetchJSON('/api/time');
+      showResponse(timeOut, res, 'No time data returned.');
+    } catch (err) {
+      showError(timeOut, 'Unable to load server time.', String(err));
+    }
   });
 
   echoForm.addEventListener('submit', async (e) => {
@@ -47,14 +104,20 @@ window.addEventListener('DOMContentLoaded', () => {
     try {
       JSON.parse(bodyText);
     } catch (err) {
-      show(echoOut, { error: 'Invalid JSON', details: String(err) });
+      showError(echoOut, 'Invalid JSON payload.', String(err));
       return;
     }
-    const res = await fetchJSON('/api/echo', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: bodyText,
-    });
-    show(echoOut, res);
+
+    showLoading(echoOut, 'Sending echo request');
+    try {
+      const res = await fetchJSON('/api/echo', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: bodyText,
+      });
+      showResponse(echoOut, res, 'No echo payload returned.');
+    } catch (err) {
+      showError(echoOut, 'Unable to send echo request.', String(err));
+    }
   });
 });

--- a/tests/web/state-styles.test.ts
+++ b/tests/web/state-styles.test.ts
@@ -1,0 +1,35 @@
+import { assertStringIncludes } from "@std/assert";
+
+const appSource = await Deno.readTextFile(
+  new URL("../../src/web/app.ts", import.meta.url),
+);
+const htmlSource = await Deno.readTextFile(
+  new URL("../../public/index.html", import.meta.url),
+);
+const stylesheet = await Deno.readTextFile(
+  new URL("../../public/styles.css", import.meta.url),
+);
+
+Deno.test("outputs start in a muted empty state", () => {
+  assertStringIncludes(htmlSource, 'id="healthOut" class="output-empty"');
+  assertStringIncludes(htmlSource, 'id="timeOut" class="output-empty"');
+  assertStringIncludes(htmlSource, 'id="echoOut" class="output-empty"');
+});
+
+Deno.test("app applies loading empty error and ready output states", () => {
+  assertStringIncludes(appSource, '"output-empty"');
+  assertStringIncludes(appSource, '"output-error"');
+  assertStringIncludes(appSource, '"output-loading"');
+  assertStringIncludes(appSource, '"output-ready"');
+  assertStringIncludes(appSource, 'setOutputState(el, "loading")');
+  assertStringIncludes(appSource, 'setOutputState(el, "empty")');
+  assertStringIncludes(appSource, 'setOutputState(el, "error")');
+  assertStringIncludes(appSource, 'setOutputState(el, "ready")');
+});
+
+Deno.test("styles define visible loading and error treatments", () => {
+  assertStringIncludes(stylesheet, ".output-error");
+  assertStringIncludes(stylesheet, ".output-loading");
+  assertStringIncludes(stylesheet, ".skeleton-line");
+  assertStringIncludes(stylesheet, "@keyframes skeleton-pulse");
+});


### PR DESCRIPTION
Closes #4.

## Summary
- Adds visible loading skeletons before each async UI request resolves.
- Adds muted empty states for the initial/empty output panels.
- Adds inline error states for failed requests and invalid JSON input.
- Keeps the implementation focused to `src/web/app.ts`, `public/index.html`, and `public/styles.css`.

## Validation
- `npx --yes deno@2.7.14 test -A tests/web/state-styles.test.ts`
- `npx --yes prettier@^3 --check src/web/app.ts public/styles.css public/index.html tests/web/state-styles.test.ts`
- `git diff --check`

Note: `deno` is not available in this local shell, so the focused output-state test was run through temporary npm Deno 2.7.14 and the changed files were checked with Prettier.

## Bounty
Preferred payout: 75 USD / USDT on Polygon PoS to `0xE7201960FEa5bFF7Ae4Fe3286093dCedabeDB003`.

/claim #4

