### PR TITLE
Add print stylesheet for clean PDF output

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -30,3 +30,108 @@ pre {
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+@media print {
+  @page {
+    margin: 0.6in;
+  }
+
+  :root {
+    color-scheme: light;
+    --bg: #fff;
+    --fg: #111;
+    --muted: #444;
+  }
+
+  * {
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  html,
+  body {
+    height: auto;
+    background: #fff !important;
+    color: #111 !important;
+  }
+
+  body {
+    font-size: 11pt;
+  }
+
+  main {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  h1,
+  h2 {
+    color: #000;
+    page-break-after: avoid;
+  }
+
+  p,
+  label,
+  pre {
+    color: #111;
+  }
+
+  section,
+  pre {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  section {
+    border-color: #bbb;
+    border-radius: 0;
+    margin: 0 0 0.35in;
+    padding: 0 0 0.25in;
+  }
+
+  section + section {
+    border-top: 1px solid #ddd;
+    padding-top: 0.25in;
+  }
+
+  pre {
+    max-height: none;
+    overflow: visible;
+    background: #fff !important;
+    border: 1px solid #bbb;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  a {
+    color: #000;
+    text-decoration: underline;
+  }
+
+  button,
+  textarea {
+    display: none !important;
+  }
+
+  nav,
+  header,
+  footer,
+  aside,
+  .app-chrome,
+  .chrome,
+  .sidebar,
+  .toolbar,
+  .actions,
+  .filters,
+  .grid-controls {
+    display: none !important;
+  }
+
+  .inspector,
+  [data-inspector] {
+    display: block !important;
+    width: 100% !important;
+    max-width: none !important;
+    grid-column: 1 / -1 !important;
+  }
+}

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -1,0 +1,11 @@
+import { assertMatch } from '@std/assert';
+
+const styles = await Deno.readTextFile('public/styles.css');
+
+Deno.test('print stylesheet keeps exported pages clean and legible', () => {
+  assertMatch(styles, /@media\s+print/);
+  assertMatch(styles, /button,\s*textarea\s*\{/);
+  assertMatch(styles, /display:\s*none\s*!important/);
+  assertMatch(styles, /page-break-inside:\s*avoid/);
+  assertMatch(styles, /background:\s*#fff\s*!important/);
+});


### PR DESCRIPTION
## Summary
- add print-specific CSS that switches to light colors, hides app chrome/form controls, and avoids awkward page breaks
- expand printed inspectors/pre blocks so PDF output stays legible
- add focused Deno coverage for the print stylesheet expectations

## Tests
- deno test -A
- deno task lint
- deno task knip
- deno run -A npm:prettier@^3 --check public/styles.css tests/styles.test.ts

Note: full `deno task fmt:check` reports a pre-existing `AGENTS.md` formatting warning on `main`; the files touched here pass Prettier.

Resolves #16