### PR TITLE
feat(ui): export visible rows to CSV

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,26 @@
       <p>Minimal Deno server with a simple UI and API.</p>
 
       <section>
+        <div class="section-header">
+          <h2>API Grid</h2>
+          <button id="exportCsv" type="button">Export CSV</button>
+        </div>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Endpoint</th>
+                <th scope="col">Method</th>
+                <th scope="col">Description</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody id="apiRows"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
         <h2>Health</h2>
         <button id="checkHealth">Check Health</button>
         <pre id="healthOut">(click to load)</pre>

--- a/public/styles.css
+++ b/public/styles.css
@@ -18,11 +18,18 @@ main { max-width: 720px; margin: 3rem auto; padding: 0 1rem; }
 h1 { font-size: 1.6rem; margin: 0 0 1rem; }
 h2 { font-size: 1.2rem; margin: 2rem 0 0.5rem; }
 section { padding: 1rem; border: 1px solid #222; border-radius: 8px; }
+.section-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.section-header h2 { margin-top: 0; }
 button {
   background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer;
   padding: 0.5rem 0.75rem; font-weight: 600; letter-spacing: 0.2px;
 }
 button:hover { filter: brightness(1.05); }
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 0.6rem 0.5rem; border-bottom: 1px solid #222; text-align: left; }
+th { color: var(--muted); font-size: 0.9rem; font-weight: 700; }
+td { vertical-align: top; }
 pre {
   background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,37 @@
+import { buildVisibleRowsCSV, type VisibleRow } from './csv.ts';
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+
+const visibleRows: VisibleRow[] = [
+  {
+    id: 'api_health',
+    endpoint: '/api/health',
+    method: 'GET',
+    description: 'Health check',
+    status: 'Ready',
+  },
+  {
+    id: 'api_time',
+    endpoint: '/api/time',
+    method: 'GET',
+    description: 'Current server time',
+    status: 'Ready',
+  },
+  {
+    id: 'api_echo',
+    endpoint: '/api/echo',
+    method: 'POST',
+    description: 'Echo JSON, text, or form data',
+    status: 'Ready',
+  },
+];
+
+const visibleColumns = [
+  { key: 'endpoint', label: 'Endpoint' },
+  { key: 'method', label: 'Method' },
+  { key: 'description', label: 'Description' },
+  { key: 'status', label: 'Status' },
+] as const;
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,6 +55,32 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
+function renderRows(tableBody: HTMLTableSectionElement) {
+  tableBody.textContent = '';
+  for (const row of visibleRows) {
+    const tr = document.createElement('tr');
+    tr.dataset.rowId = row.id;
+    for (const column of visibleColumns) {
+      const cell = document.createElement('td');
+      cell.textContent = row[column.key];
+      tr.append(cell);
+    }
+    tableBody.append(tr);
+  }
+}
+
+function downloadCSV(csv: string) {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'os-ubq-visible-rows.csv';
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
@@ -30,6 +89,14 @@ window.addEventListener('DOMContentLoaded', () => {
   const echoForm = byId<HTMLFormElement>('echoForm');
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
   const echoOut = byId<HTMLPreElement>('echoOut');
+  const exportCsvBtn = byId<HTMLButtonElement>('exportCsv');
+  const apiRows = byId<HTMLTableSectionElement>('apiRows');
+
+  renderRows(apiRows);
+
+  exportCsvBtn.addEventListener('click', () => {
+    downloadCSV(buildVisibleRowsCSV(visibleRows));
+  });
 
   healthBtn.addEventListener('click', async () => {
     const res = await fetchJSON('/api/health');

--- a/src/web/csv.ts
+++ b/src/web/csv.ts
@@ -1,0 +1,30 @@
+export type VisibleRow = {
+  id: string;
+  endpoint: string;
+  method: string;
+  description: string;
+  status: string;
+};
+
+const visibleColumns = [
+  { key: 'endpoint', label: 'Endpoint' },
+  { key: 'method', label: 'Method' },
+  { key: 'description', label: 'Description' },
+  { key: 'status', label: 'Status' },
+] as const;
+
+function escapeCSVCell(value: unknown): string {
+  const text = String(value ?? '');
+  if (/[",\r\n]/.test(text)) {
+    return `"${text.replaceAll('"', '""')}"`;
+  }
+  return text;
+}
+
+export function buildVisibleRowsCSV(rows: VisibleRow[]): string {
+  const header = visibleColumns.map((column) => escapeCSVCell(column.label)).join(',');
+  const body = rows.map((row) =>
+    visibleColumns.map((column) => escapeCSVCell(row[column.key])).join(','),
+  );
+  return [header, ...body].join('\r\n');
+}

--- a/tests/web/app.test.ts
+++ b/tests/web/app.test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from '@std/assert';
+import { buildVisibleRowsCSV } from '../../src/web/csv.ts';
+
+Deno.test('buildVisibleRowsCSV exports visible columns and excludes raw ids', () => {
+  const csv = buildVisibleRowsCSV([
+    {
+      id: 'internal_001',
+      endpoint: '/api/example',
+      method: 'GET',
+      description: 'Visible endpoint',
+      status: 'Ready',
+    },
+  ]);
+
+  assertEquals(
+    csv,
+    'Endpoint,Method,Description,Status\r\n/api/example,GET,Visible endpoint,Ready',
+  );
+  assertEquals(csv.includes('internal_001'), false);
+});
+
+Deno.test('buildVisibleRowsCSV escapes values for spreadsheet apps', () => {
+  const csv = buildVisibleRowsCSV([
+    {
+      id: 'internal_002',
+      endpoint: '/api/echo',
+      method: 'POST',
+      description: 'Echo "JSON", text, or form data',
+      status: 'Ready\nNow',
+    },
+  ]);
+
+  assertEquals(
+    csv,
+    'Endpoint,Method,Description,Status\r\n/api/echo,POST,"Echo ""JSON"", text, or form data","Ready\nNow"',
+  );
+});


### PR DESCRIPTION
Closes #14

## Summary
- Add a visible API grid with an Export CSV action.
- Generate CSV from visible columns only, excluding internal row ids.
- Escape CSV cells so values open cleanly in spreadsheet apps.

## Validation
- npx --yes deno@latest task test
- npx --yes deno@latest task build:client
- npx --yes deno@latest task lint

## Payment
Wallet: 0x0768952aE33662F8B099D8e1273eb6C96652bb3B