### PR TITLE
feat(ui): export current view json

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>os.ubq.fi — Minimal Deno Server</title>
+    <link rel="icon" href="data:," />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -24,6 +25,22 @@
       </section>
 
       <section>
+        <h2>Current view</h2>
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">ID</th>
+              <th scope="col">Title</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody id="currentViewBody"></tbody>
+        </table>
+        <button id="exportJSON">Export JSON</button>
+        <pre id="exportJSONOut">(export preview)</pre>
+      </section>
+
+      <section>
         <h2>Echo</h2>
         <form id="echoForm">
           <label>
@@ -38,4 +55,4 @@
 
     <script type="module" defer src="/assets/app.js"></script>
   </body>
-  </html>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -27,6 +27,20 @@ pre {
   background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
+table {
+  width: 100%;
+  margin: 0 0 0.75rem;
+  border-collapse: collapse;
+}
+th,
+td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #222;
+  text-align: left;
+}
+th {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
-

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,15 @@
+/// <reference lib="dom" />
+
+import { buildCurrentViewExport, type CurrentViewRow } from './currentViewExport.ts';
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+
+const CURRENT_VIEW_COLUMNS = ['id', 'title', 'status'] as const;
+const CURRENT_VIEW_ROWS: CurrentViewRow[] = [
+  { id: 'iss_0001', title: 'URL state and deep links', status: 'open' },
+  { id: 'iss_0002', title: 'Sortable headers', status: 'open' },
+  { id: 'iss_0003', title: 'Filter chips', status: 'open' },
+];
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,14 +33,51 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
+function renderCurrentView(tbody: HTMLTableSectionElement) {
+  tbody.replaceChildren();
+  for (const row of CURRENT_VIEW_ROWS) {
+    const tr = document.createElement('tr');
+    for (const column of CURRENT_VIEW_COLUMNS) {
+      const td = document.createElement('td');
+      td.textContent = String(row[column] ?? '');
+      tr.append(td);
+    }
+    tbody.append(tr);
+  }
+}
+
+function currentViewPayload() {
+  return buildCurrentViewExport([...CURRENT_VIEW_COLUMNS], CURRENT_VIEW_ROWS, {
+    table: 'issues',
+    offset: 0,
+    limit: CURRENT_VIEW_ROWS.length,
+  });
+}
+
+function downloadJSON(payload: unknown) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'current-view.json';
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
   const timeOut = byId<HTMLPreElement>('timeOut');
+  const currentViewBody = byId<HTMLTableSectionElement>('currentViewBody');
+  const exportJSONBtn = byId<HTMLButtonElement>('exportJSON');
+  const exportJSONOut = byId<HTMLPreElement>('exportJSONOut');
   const echoForm = byId<HTMLFormElement>('echoForm');
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
   const echoOut = byId<HTMLPreElement>('echoOut');
+
+  renderCurrentView(currentViewBody);
+  show(exportJSONOut, currentViewPayload());
 
   healthBtn.addEventListener('click', async () => {
     const res = await fetchJSON('/api/health');
@@ -39,6 +87,12 @@ window.addEventListener('DOMContentLoaded', () => {
   timeBtn.addEventListener('click', async () => {
     const res = await fetchJSON('/api/time');
     show(timeOut, res);
+  });
+
+  exportJSONBtn.addEventListener('click', () => {
+    const payload = currentViewPayload();
+    show(exportJSONOut, payload);
+    downloadJSON(payload);
   });
 
   echoForm.addEventListener('submit', async (e) => {

--- a/src/web/currentViewExport.ts
+++ b/src/web/currentViewExport.ts
@@ -1,0 +1,32 @@
+export type CurrentViewRow = Record<string, string | number | boolean | null>;
+
+type CurrentViewMeta = {
+  table: string;
+  offset: number;
+  limit: number;
+};
+
+export function buildCurrentViewExport(
+  columns: string[],
+  rows: CurrentViewRow[],
+  meta: CurrentViewMeta,
+  exportedAt = new Date(),
+) {
+  return {
+    columns,
+    rows: rows.map((row) => pickColumns(row, columns)),
+    meta: {
+      ...meta,
+      rowCount: rows.length,
+      exportedAt: exportedAt.toISOString(),
+    },
+  };
+}
+
+function pickColumns(row: CurrentViewRow, columns: string[]): CurrentViewRow {
+  const picked: CurrentViewRow = {};
+  for (const column of columns) {
+    picked[column] = row[column] ?? null;
+  }
+  return picked;
+}

--- a/tests/currentViewExport.test.ts
+++ b/tests/currentViewExport.test.ts
@@ -1,0 +1,34 @@
+import { buildCurrentViewExport } from '../src/web/currentViewExport.ts';
+
+function assertEquals(actual: unknown, expected: unknown) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+Deno.test('buildCurrentViewExport preserves current columns rows and meta', () => {
+  const payload = buildCurrentViewExport(
+    ['id', 'status'],
+    [
+      { id: 'iss_0001', status: 'open', hidden: 'ignored' },
+      { id: 'iss_0002', status: 'closed', hidden: 'ignored' },
+    ],
+    { table: 'issues', offset: 0, limit: 2 },
+    new Date(0),
+  );
+
+  assertEquals(payload, {
+    columns: ['id', 'status'],
+    rows: [
+      { id: 'iss_0001', status: 'open' },
+      { id: 'iss_0002', status: 'closed' },
+    ],
+    meta: {
+      table: 'issues',
+      offset: 0,
+      limit: 2,
+      rowCount: 2,
+      exportedAt: '1970-01-01T00:00:00.000Z',
+    },
+  });
+});


### PR DESCRIPTION
Closes #15.

/claim #15

## Summary
- Add a small current-view table and an `Export JSON` action.
- Generate the client-side payload as `{ columns, rows, meta }`, with rows limited to the visible columns and metadata for table, offset, limit, row count, and export time.
- Add focused regression coverage for preserving the current slice accurately.

## Verification
- `deno test -A tests/currentViewExport.test.ts`
- `deno check src/web/app.ts src/web/currentViewExport.ts tests/currentViewExport.test.ts`
- `deno task build:client`
- `deno run -A npm:prettier@^3 --check src/web/app.ts src/web/currentViewExport.ts tests/currentViewExport.test.ts public/index.html public/styles.css deno.json README.md`
- `deno task lint`
- `deno task knip`
- `git diff --check`
- Browser smoke via static server: current-view rows rendered, `Export JSON` downloaded `current-view.json`, and the current console after reload/click had 0 warnings/errors.

Note: full `deno task build` is currently blocked in this restricted environment by the existing server-side `@std/http` JSR fetch on `main`; the client bundle for this issue passes.
