### PR TITLE
feat(ui): improve issue grid accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,10 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>os.ubq.fi — Minimal Deno Server</title>
+    <link rel="icon" href="data:," />
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
-    <main>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <main id="main-content" tabindex="-1">
       <h1>os.ubq.fi</h1>
       <p>Minimal Deno server with a simple UI and API.</p>
 
@@ -21,6 +23,63 @@
         <h2>Time</h2>
         <button id="getTime">Get Time</button>
         <pre id="timeOut">(click to load)</pre>
+      </section>
+
+      <section aria-labelledby="issuesHeading">
+        <h2 id="issuesHeading">Issues</h2>
+        <p id="issueTableHelp" class="sr-only">
+          Tab to the issues grid, use arrow keys to move between rows, and press Enter or Space to
+          show or hide issue details.
+        </p>
+        <div class="table-shell">
+          <table aria-label="Issues" aria-describedby="issueTableHelp" role="grid">
+            <thead>
+              <tr>
+                <th aria-sort="none">
+                  <button type="button" class="sort-header" data-sort="id">
+                    ID <span aria-hidden="true"></span>
+                  </button>
+                </th>
+                <th aria-sort="none">
+                  <button type="button" class="sort-header" data-sort="title">
+                    Title <span aria-hidden="true"></span>
+                  </button>
+                </th>
+                <th aria-sort="none">
+                  <button type="button" class="sort-header" data-sort="status">
+                    Status <span aria-hidden="true"></span>
+                  </button>
+                </th>
+                <th aria-sort="none">
+                  <button type="button" class="sort-header" data-sort="created">
+                    Created <span aria-hidden="true"></span>
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="issueRows">
+              <tr>
+                <td colspan="4">Loading rows...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <aside
+          id="issueInspectorPanel"
+          class="issue-inspector"
+          role="region"
+          aria-labelledby="issueInspectorTitle"
+          aria-live="polite"
+          tabindex="-1"
+        >
+          <h3 id="issueInspectorTitle">Selected issue</h3>
+          <dl id="issueInspector">
+            <div>
+              <dt>Status</dt>
+              <dd>Select a row or open a URL with <code>rowId</code>.</dd>
+            </div>
+          </dl>
+        </aside>
       </section>
 
       <section>
@@ -38,4 +97,4 @@
 
     <script type="module" defer src="/assets/app.js"></script>
   </body>
-  </html>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -3,6 +3,7 @@
   --bg: #0b0c0f;
   --fg: #e6e8ea;
   --accent: #7cd7ff;
+  --focus: #f6c945;
   --muted: #9aa4af;
 }
 
@@ -15,6 +16,7 @@ body {
   color: var(--fg);
 }
 main { max-width: 720px; margin: 3rem auto; padding: 0 1rem; }
+main:focus { outline: none; }
 h1 { font-size: 1.6rem; margin: 0 0 1rem; }
 h2 { font-size: 1.2rem; margin: 2rem 0 0.5rem; }
 section { padding: 1rem; border: 1px solid #222; border-radius: 8px; }
@@ -23,10 +25,130 @@ button {
   padding: 0.5rem 0.75rem; font-weight: 600; letter-spacing: 0.2px;
 }
 button:hover { filter: brightness(1.05); }
+button:focus-visible,
+textarea:focus-visible,
+tbody tr.row-link:focus-visible,
+.issue-inspector:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
 pre {
   background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
-
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 0;
+  z-index: 1;
+  transform: translateY(-120%);
+  background: var(--focus);
+  border-radius: 0 0 6px 6px;
+  color: #0b0c0f;
+  font-weight: 700;
+  padding: 0.5rem 0.75rem;
+  text-decoration: none;
+  transition: transform 140ms ease;
+}
+.skip-link:focus {
+  transform: translateY(0);
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.table-shell {
+  overflow-x: auto;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+th,
+td {
+  border-bottom: 1px solid #1b1f2a;
+  padding: 0.6rem 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+tbody tr {
+  transition:
+    background 140ms ease,
+    color 140ms ease;
+}
+tbody tr.row-link {
+  cursor: pointer;
+}
+tbody tr.row-link:hover,
+tbody tr.row-link:focus {
+  background: rgba(124, 215, 255, 0.08);
+}
+tbody tr.row-link[aria-selected="true"] {
+  background: rgba(124, 215, 255, 0.14);
+  color: #ffffff;
+}
+.sort-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 2rem;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+.sort-header:hover {
+  color: var(--accent);
+  filter: none;
+}
+.sort-header span {
+  display: inline-block;
+  min-width: 1ch;
+  color: var(--accent);
+}
+.issue-inspector {
+  margin-top: 1rem;
+  padding: 0.85rem;
+  border: 1px solid #1b1f2a;
+  border-radius: 8px;
+  background: #0f1115;
+}
+.issue-inspector h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+.issue-inspector dl {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+}
+.issue-inspector div {
+  display: grid;
+  grid-template-columns: minmax(5rem, 8rem) 1fr;
+  gap: 0.75rem;
+}
+.issue-inspector dt {
+  color: var(--muted);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+.issue-inspector dd {
+  margin: 0;
+}
+.issue-inspector code {
+  color: var(--accent);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,41 @@
-import { serveDir } from '@std/http/file-server';
-
 const PUBLIC_DIR = Deno.env.get('PUBLIC_DIR') ?? 'public';
 const PORT = Number.parseInt(Deno.env.get('PORT') ?? '8000');
+
+type IssueRow = {
+  id: string;
+  title: string;
+  status: string;
+  created: string;
+};
+
+const ISSUE_ROWS: IssueRow[] = [
+  {
+    id: 'iss_0001',
+    title: 'Sorting header state',
+    status: 'open',
+    created: '2026-01-12',
+  },
+  {
+    id: 'iss_0002',
+    title: 'Plugin health monitor',
+    status: 'assigned',
+    created: '2026-02-04',
+  },
+  {
+    id: 'iss_0003',
+    title: 'Dynamic sitemap refresh',
+    status: 'open',
+    created: '2026-03-18',
+  },
+  {
+    id: 'iss_0004',
+    title: 'Contributor reward proof',
+    status: 'done',
+    created: '2026-04-02',
+  },
+];
+
+const ISSUE_SORT_FIELDS = new Set<keyof IssueRow>(['id', 'title', 'status', 'created']);
 
 export async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
@@ -18,6 +52,10 @@ export async function handler(req: Request): Promise<Response> {
       if (pathname === '/api/time' && req.method === 'GET') {
         const now = new Date();
         return json({ iso: now.toISOString(), epochMS: now.getTime() });
+      }
+
+      if (pathname === '/api/sb/rows' && req.method === 'GET') {
+        return rows(url.searchParams);
       }
 
       if (pathname === '/api/echo' && req.method === 'POST') {
@@ -50,12 +88,8 @@ export async function handler(req: Request): Promise<Response> {
       return notFound();
     }
 
-    // Static file serving for everything else
-    return await serveDir(req, {
-      fsRoot: PUBLIC_DIR,
-      showIndex: true,
-      quiet: true,
-    });
+    // Static file serving for everything else.
+    return await serveStatic(pathname);
   } catch (err) {
     console.error('Request error:', err);
     return new Response('Internal Server Error', { status: 500 });
@@ -70,8 +104,52 @@ function json(data: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(data), { ...init, headers });
 }
 
+function rows(params: URLSearchParams): Response {
+  const table = params.get('table') ?? 'issues';
+  if (table !== 'issues') {
+    return json({ error: `Unsupported table "${table}"` }, { status: 400 });
+  }
+
+  const requestedSort = params.get('sort') ?? 'id';
+  const sort = ISSUE_SORT_FIELDS.has(requestedSort as keyof IssueRow)
+    ? (requestedSort as keyof IssueRow)
+    : 'id';
+  const desc = params.get('desc') === 'true';
+  const rows = [...ISSUE_ROWS].sort((left, right) => {
+    const order = left[sort].localeCompare(right[sort]);
+    return desc ? -order : order;
+  });
+
+  return json({ table, sort, desc, rows });
+}
+
 function notFound(): Response {
   return new Response('Not Found', { status: 404 });
+}
+
+async function serveStatic(pathname: string): Promise<Response> {
+  const relativePath = pathname === '/' ? 'index.html' : pathname.slice(1);
+  if (relativePath.includes('..')) {
+    return notFound();
+  }
+
+  try {
+    const file = await Deno.readFile(`${PUBLIC_DIR}/${relativePath}`);
+    return new Response(file, {
+      headers: { 'content-type': contentType(relativePath) },
+    });
+  } catch {
+    return notFound();
+  }
+}
+
+function contentType(path: string): string {
+  if (path.endsWith('.html')) return 'text/html; charset=utf-8';
+  if (path.endsWith('.css')) return 'text/css; charset=utf-8';
+  if (path.endsWith('.js')) return 'text/javascript; charset=utf-8';
+  if (path.endsWith('.json')) return 'application/json; charset=utf-8';
+  if (path.endsWith('.svg')) return 'image/svg+xml';
+  return 'application/octet-stream';
 }
 
 if (import.meta.main) {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,18 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+type IssueRow = {
+  id: string;
+  title: string;
+  status: string;
+  created: string;
+};
+
+type RowsResponse = {
+  sort: keyof IssueRow;
+  desc: boolean;
+  rows: IssueRow[];
+};
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -27,9 +41,14 @@ window.addEventListener('DOMContentLoaded', () => {
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
   const timeOut = byId<HTMLPreElement>('timeOut');
+  const issueRows = byId<HTMLTableSectionElement>('issueRows');
+  const issueInspector = byId<HTMLElement>('issueInspector');
+  const sortHeaders = [...document.querySelectorAll<HTMLButtonElement>('.sort-header')];
   const echoForm = byId<HTMLFormElement>('echoForm');
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
   const echoOut = byId<HTMLPreElement>('echoOut');
+  let rows: IssueRow[] = [];
+  let focusedRowIndex = 0;
 
   healthBtn.addEventListener('click', async () => {
     const res = await fetchJSON('/api/health');
@@ -39,6 +58,153 @@ window.addEventListener('DOMContentLoaded', () => {
   timeBtn.addEventListener('click', async () => {
     const res = await fetchJSON('/api/time');
     show(timeOut, res);
+  });
+
+  async function loadIssueRows() {
+    const params = new URLSearchParams(window.location.search);
+    const sort = params.get('sort') ?? 'id';
+    const desc = params.get('desc') === 'true';
+    const res = await fetchJSON(
+      `/api/sb/rows?table=issues&sort=${encodeURIComponent(sort)}&desc=${desc}`,
+    );
+
+    if (!res.ok || !isRowsResponse(res.data)) {
+      rows = [];
+      focusedRowIndex = 0;
+      issueRows.innerHTML = `<tr><td colspan="4">Unable to load rows.</td></tr>`;
+      return;
+    }
+
+    rows = res.data.rows;
+    const rowId = params.get('rowId');
+    const selectedIndex = rowId ? rows.findIndex((row) => row.id === rowId) : -1;
+    focusedRowIndex = selectedIndex >= 0 ? selectedIndex : 0;
+    issueRows.replaceChildren(...rows.map((row, index) => renderRow(row, index, rowId)));
+
+    const selected = selectedIndex >= 0 ? rows[selectedIndex] : null;
+    renderIssueInspector(selected ?? null, rowId);
+    updateSortHeaders(res.data);
+  }
+
+  function renderRow(row: IssueRow, index: number, selectedRowId: string | null) {
+    const isSelected = selectedRowId === row.id;
+    const tr = document.createElement('tr');
+    tr.className = 'row-link';
+    tr.tabIndex = index === focusedRowIndex ? 0 : -1;
+    tr.dataset.rowId = row.id;
+    tr.setAttribute('aria-selected', String(isSelected));
+    tr.setAttribute('aria-expanded', String(isSelected));
+    tr.setAttribute('aria-controls', 'issueInspectorPanel');
+    tr.addEventListener('click', () => toggleIssueRow(row));
+    tr.addEventListener('keydown', (event) => handleIssueRowKeydown(event, row, index));
+    tr.append(cell(row.id), cell(row.title), cell(row.status), cell(row.created));
+    return tr;
+  }
+
+  function handleIssueRowKeydown(event: KeyboardEvent, row: IssueRow, index: number) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleIssueRow(row);
+      return;
+    }
+
+    const nextIndex = nextFocusedIndex(event.key, index);
+    if (nextIndex === index) return;
+
+    event.preventDefault();
+    focusIssueRow(nextIndex);
+  }
+
+  function nextFocusedIndex(key: string, index: number) {
+    if (key === 'ArrowDown') return Math.min(index + 1, rows.length - 1);
+    if (key === 'ArrowUp') return Math.max(index - 1, 0);
+    if (key === 'Home') return 0;
+    if (key === 'End') return Math.max(rows.length - 1, 0);
+    return index;
+  }
+
+  function focusIssueRow(index: number) {
+    focusedRowIndex = index;
+    const rowElements = [...issueRows.querySelectorAll<HTMLTableRowElement>('tr[data-row-id]')];
+    for (const [rowIndex, tr] of rowElements.entries()) {
+      tr.tabIndex = rowIndex === focusedRowIndex ? 0 : -1;
+    }
+    rowElements[focusedRowIndex]?.focus();
+  }
+
+  function toggleIssueRow(row: IssueRow) {
+    const params = new URLSearchParams(window.location.search);
+    const isExpanded = params.get('rowId') === row.id;
+    if (isExpanded) {
+      params.delete('rowId');
+      history.pushState(null, '', formatSearch(params));
+      updateRowSelection(null);
+      renderIssueInspector(null, null);
+      return;
+    }
+
+    params.set('rowId', row.id);
+    history.pushState(null, '', formatSearch(params));
+    updateRowSelection(row.id);
+    renderIssueInspector(row, row.id);
+  }
+
+  function updateRowSelection(rowId: string | null) {
+    for (const tr of issueRows.querySelectorAll<HTMLTableRowElement>('tr[data-row-id]')) {
+      const isSelected = tr.dataset.rowId === rowId;
+      tr.setAttribute('aria-selected', String(isSelected));
+      tr.setAttribute('aria-expanded', String(isSelected));
+    }
+  }
+
+  function renderIssueInspector(row: IssueRow | null, requestedRowId: string | null) {
+    if (!row) {
+      const message = requestedRowId
+        ? `No issue row found for ${requestedRowId}.`
+        : 'Select a row or open a URL with rowId.';
+      issueInspector.replaceChildren(inspectorItem('Status', message));
+      return;
+    }
+
+    issueInspector.replaceChildren(
+      inspectorItem('ID', row.id),
+      inspectorItem('Title', row.title),
+      inspectorItem('Status', row.status),
+      inspectorItem('Created', row.created),
+    );
+  }
+
+  function updateSortHeaders(data: RowsResponse) {
+    for (const button of sortHeaders) {
+      const isActive = button.dataset.sort === data.sort;
+      const sortDirection = isActive ? (data.desc ? 'descending' : 'ascending') : 'none';
+      button.closest('th')?.setAttribute('aria-sort', sortDirection);
+      button.setAttribute(
+        'aria-label',
+        `${button.textContent?.trim() ?? 'Column'}: sort ${
+          isActive && !data.desc ? 'descending' : 'ascending'
+        }`,
+      );
+      const indicator = button.querySelector('span');
+      if (indicator) indicator.textContent = isActive ? (data.desc ? '↓' : '↑') : '';
+    }
+  }
+
+  for (const button of sortHeaders) {
+    button.addEventListener('click', () => {
+      const params = new URLSearchParams(window.location.search);
+      const nextSort = button.dataset.sort ?? 'id';
+      const currentSort = params.get('sort') ?? 'id';
+      const currentDesc = params.get('desc') === 'true';
+      params.set('sort', nextSort);
+      params.set('desc', String(currentSort === nextSort ? !currentDesc : false));
+      history.pushState(null, '', formatSearch(params));
+      void loadIssueRows();
+    });
+  }
+
+  window.addEventListener('popstate', () => {
+    void loadIssueRows();
   });
 
   echoForm.addEventListener('submit', async (e) => {
@@ -57,4 +223,37 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
+
+  void loadIssueRows();
 });
+
+function cell(value: string): HTMLTableCellElement {
+  const td = document.createElement('td');
+  td.textContent = value;
+  return td;
+}
+
+function inspectorItem(label: string, value: string): HTMLDivElement {
+  const item = document.createElement('div');
+  const dt = document.createElement('dt');
+  const dd = document.createElement('dd');
+  dt.textContent = label;
+  dd.textContent = value;
+  item.append(dt, dd);
+  return item;
+}
+
+function formatSearch(params: URLSearchParams) {
+  const search = params.toString();
+  return search ? `?${search}` : window.location.pathname;
+}
+
+function isRowsResponse(data: unknown): data is RowsResponse {
+  if (!data || typeof data !== 'object') return false;
+  const candidate = data as Partial<RowsResponse>;
+  return (
+    typeof candidate.sort === 'string' &&
+    typeof candidate.desc === 'boolean' &&
+    Array.isArray(candidate.rows)
+  );
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,5 +1,10 @@
-import { assertEquals } from '@std/assert';
 import { handler } from '../src/server.ts';
+
+function assertEquals(actual: unknown, expected: unknown) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
 
 Deno.test('GET /api/health returns ok', async () => {
   const res = await handler(new Request('http://localhost/api/health'));
@@ -16,6 +21,39 @@ Deno.test('GET /api/time returns iso timestamp', async () => {
   const data = await res.json();
   assertEquals(typeof data.iso, 'string');
   assertEquals(typeof data.epochMS, 'number');
+});
+
+Deno.test('GET /api/sb/rows sorts issues by header field ascending', async () => {
+  const res = await handler(new Request('http://localhost/api/sb/rows?table=issues&sort=title'));
+  assertEquals(res.status, 200);
+  const data = await res.json();
+
+  assertEquals(data.sort, 'title');
+  assertEquals(data.desc, false);
+  assertEquals(
+    data.rows.map((row: { title: string }) => row.title),
+    [
+      'Contributor reward proof',
+      'Dynamic sitemap refresh',
+      'Plugin health monitor',
+      'Sorting header state',
+    ],
+  );
+});
+
+Deno.test('GET /api/sb/rows sorts issues by header field descending', async () => {
+  const res = await handler(
+    new Request('http://localhost/api/sb/rows?table=issues&sort=created&desc=true'),
+  );
+  assertEquals(res.status, 200);
+  const data = await res.json();
+
+  assertEquals(data.sort, 'created');
+  assertEquals(data.desc, true);
+  assertEquals(
+    data.rows.map((row: { id: string }) => row.id),
+    ['iss_0004', 'iss_0003', 'iss_0002', 'iss_0001'],
+  );
 });
 
 Deno.test('POST /api/echo returns same JSON', async () => {


### PR DESCRIPTION
Closes #21.

/claim #21

## Summary
- Add an issues grid with sortable sample rows and a selected-issue inspector.
- Add ARIA labels/regions, `aria-sort`, row `aria-selected`/`aria-expanded`, and a skip link.
- Add roving keyboard navigation for issue rows: ArrowUp/ArrowDown/Home/End move focus, Enter/Space toggle the inspector.

## Verification
- `deno run -A npm:prettier@^3 --check public/index.html public/styles.css src/server.ts src/web/app.ts tests/server.test.ts`
- `deno task build:client`
- `deno task lint`
- `deno task knip`
- `deno test -A --coverage=coverage`
- Browser smoke at `http://127.0.0.1:8178`: focused first issue row, ArrowDown moved focus to `iss_0002`, Enter expanded the inspector, Space collapsed it again.
