### PR TITLE
Persist sidebar table state

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,34 +7,44 @@
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
-    <main>
-      <h1>os.ubq.fi</h1>
-      <p>Minimal Deno server with a simple UI and API.</p>
+    <div class="app-shell">
+      <aside id="sidebar" class="sidebar" aria-label="Tables">
+        <h1>os.ubq.fi</h1>
+        <nav class="table-nav" aria-label="Table list">
+          <button type="button" data-table-button="health">Health</button>
+          <button type="button" data-table-button="time">Time</button>
+          <button type="button" data-table-button="echo">Echo</button>
+        </nav>
+      </aside>
 
-      <section>
-        <h2>Health</h2>
-        <button id="checkHealth">Check Health</button>
-        <pre id="healthOut">(click to load)</pre>
-      </section>
+      <main>
+        <p>Minimal Deno server with a simple UI and API.</p>
 
-      <section>
-        <h2>Time</h2>
-        <button id="getTime">Get Time</button>
-        <pre id="timeOut">(click to load)</pre>
-      </section>
+        <section id="panel-health" data-table-panel="health">
+          <h2>Health</h2>
+          <button id="checkHealth">Check Health</button>
+          <pre id="healthOut">(click to load)</pre>
+        </section>
 
-      <section>
-        <h2>Echo</h2>
-        <form id="echoForm">
-          <label>
-            JSON payload
-            <textarea id="echoInput" rows="4" placeholder='{"hello":"world"}'></textarea>
-          </label>
-          <button type="submit">POST /api/echo</button>
-        </form>
-        <pre id="echoOut">(submit to send)</pre>
-      </section>
-    </main>
+        <section id="panel-time" data-table-panel="time" hidden>
+          <h2>Time</h2>
+          <button id="getTime">Get Time</button>
+          <pre id="timeOut">(click to load)</pre>
+        </section>
+
+        <section id="panel-echo" data-table-panel="echo" hidden>
+          <h2>Echo</h2>
+          <form id="echoForm">
+            <label>
+              JSON payload
+              <textarea id="echoInput" rows="4" placeholder='{"hello":"world"}'></textarea>
+            </label>
+            <button type="submit">POST /api/echo</button>
+          </form>
+          <pre id="echoOut">(submit to send)</pre>
+        </section>
+      </main>
+    </div>
 
     <script type="module" defer src="/assets/app.js"></script>
   </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -14,10 +14,42 @@ body {
   background: var(--bg);
   color: var(--fg);
 }
-main { max-width: 720px; margin: 3rem auto; padding: 0 1rem; }
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(13rem, 18rem) minmax(0, 1fr);
+  min-height: 100%;
+}
+.sidebar {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  height: 100vh;
+  overflow: auto;
+  border-right: 1px solid #222;
+  padding: 2rem 1rem;
+}
+.table-nav {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+.table-nav button {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 1px solid #222;
+  color: var(--fg);
+}
+.table-nav button:hover,
+.table-nav button.is-active {
+  border-color: #2a8cd8;
+  background: #102033;
+}
+main { max-width: 720px; margin: 3rem auto; padding: 0 1rem; width: 100%; }
 h1 { font-size: 1.6rem; margin: 0 0 1rem; }
 h2 { font-size: 1.2rem; margin: 2rem 0 0.5rem; }
 section { padding: 1rem; border: 1px solid #222; border-radius: 8px; }
+section[hidden] { display: none; }
 button {
   background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer;
   padding: 0.5rem 0.75rem; font-weight: 600; letter-spacing: 0.2px;
@@ -30,3 +62,20 @@ pre {
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+@media (max-width: 720px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+    height: auto;
+    max-height: 40vh;
+    border-right: 0;
+    border-bottom: 1px solid #222;
+  }
+
+  main {
+    margin: 1.5rem auto;
+  }
+}

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,12 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+
+const TABLE_IDS = ['health', 'time', 'echo'] as const;
+type TableId = (typeof TABLE_IDS)[number];
+
+const LAST_TABLE_STORAGE_KEY = 'os.ubq.fi:lastTable';
+const SIDEBAR_SCROLL_STORAGE_KEY = 'os.ubq.fi:sidebarScrollTop';
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,7 +30,92 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function isTableId(value: string | null | undefined): value is TableId {
+  return TABLE_IDS.includes(value as TableId);
+}
+
+export function resolveInitialTable(urlTable: string | null, storedTable: string | null): TableId {
+  if (isTableId(urlTable)) return urlTable;
+  if (isTableId(storedTable)) return storedTable;
+  return 'health';
+}
+
+export function parseStoredScrollTop(value: string | null): number {
+  if (value === null) return 0;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function readStorage(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(key: string, value: string) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+}
+
+function initSidebarPersistence() {
+  const sidebar = byId<HTMLElement>('sidebar');
+  const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-table-button]'));
+  const panels = new Map(
+    TABLE_IDS.map((tableId) => [tableId, byId<HTMLElement>(`panel-${tableId}`)]),
+  );
+
+  function activateTable(tableId: TableId, updateUrl: boolean) {
+    for (const button of buttons) {
+      const active = button.dataset.tableButton === tableId;
+      button.setAttribute('aria-pressed', String(active));
+      button.classList.toggle('is-active', active);
+    }
+
+    for (const [panelTableId, panel] of panels) {
+      panel.hidden = panelTableId !== tableId;
+    }
+
+    writeStorage(LAST_TABLE_STORAGE_KEY, tableId);
+
+    if (updateUrl) {
+      const url = new URL(window.location.href);
+      url.searchParams.set('table', tableId);
+      window.history.replaceState(null, '', url);
+    }
+  }
+
+  const initialTable = resolveInitialTable(
+    new URLSearchParams(window.location.search).get('table'),
+    readStorage(LAST_TABLE_STORAGE_KEY),
+  );
+
+  activateTable(initialTable, false);
+
+  requestAnimationFrame(() => {
+    sidebar.scrollTop = parseStoredScrollTop(readStorage(SIDEBAR_SCROLL_STORAGE_KEY));
+  });
+
+  sidebar.addEventListener('scroll', () => {
+    writeStorage(SIDEBAR_SCROLL_STORAGE_KEY, String(Math.max(0, Math.round(sidebar.scrollTop))));
+  });
+
+  for (const button of buttons) {
+    button.addEventListener('click', () => {
+      if (isTableId(button.dataset.tableButton)) {
+        activateTable(button.dataset.tableButton, true);
+      }
+    });
+  }
+}
+
+function initApp() {
+  initSidebarPersistence();
+
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -57,4 +150,8 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
-});
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initApp);
+}

--- a/tests/web/app.test.ts
+++ b/tests/web/app.test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from '@std/assert';
+import { parseStoredScrollTop, resolveInitialTable } from '../../src/web/app.ts';
+
+Deno.test('resolveInitialTable prefers valid URL table', () => {
+  assertEquals(resolveInitialTable('time', 'echo'), 'time');
+});
+
+Deno.test('resolveInitialTable falls back to stored table', () => {
+  assertEquals(resolveInitialTable(null, 'echo'), 'echo');
+});
+
+Deno.test('resolveInitialTable ignores invalid values', () => {
+  assertEquals(resolveInitialTable('unknown', 'also-unknown'), 'health');
+});
+
+Deno.test('parseStoredScrollTop accepts non-negative numbers', () => {
+  assertEquals(parseStoredScrollTop('42'), 42);
+  assertEquals(parseStoredScrollTop('0'), 0);
+});
+
+Deno.test('parseStoredScrollTop rejects invalid values', () => {
+  assertEquals(parseStoredScrollTop(null), 0);
+  assertEquals(parseStoredScrollTop('-1'), 0);
+  assertEquals(parseStoredScrollTop('not-a-number'), 0);
+});


### PR DESCRIPTION
Resolves #11

/claim #11

## Summary
- add a sidebar table switcher for the existing Health, Time, and Echo panels
- persist the last selected table and sidebar scrollTop in localStorage
- restore the saved table when returning without a `table` query parameter
- add focused helper tests for table and scroll restoration parsing

## Verification
- `npx --yes deno@2.7.14 check src/web/app.ts src/server.ts tests/server.test.ts tests/web/app.test.ts`
- `npx --yes deno@2.7.14 task test`
- `npx --yes deno@2.7.14 task lint`
- `npx --yes deno@2.7.14 task knip`
- `npx --yes deno@2.7.14 task build:client`
- `npx --yes prettier@^3 --check src/web/app.ts public/index.html public/styles.css tests/web/app.test.ts`
- `git diff --check`
- Browser smoke via local Chrome at `http://127.0.0.1:8175/`: selected Echo, confirmed URL became `?table=echo`, the `os.ubq.fi:lastTable` localStorage key became `echo`, Health panel was hidden, Echo panel was visible, then reloaded `/` and confirmed Echo restored from localStorage.