### PR TITLE
feat(ui): add saved views

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,25 @@
       <h1>os.ubq.fi</h1>
       <p>Minimal Deno server with a simple UI and API.</p>
 
+      <section aria-labelledby="savedViewsHeading">
+        <h2 id="savedViewsHeading">Saved Views</h2>
+        <form id="savedViewForm" class="saved-view-form">
+          <label>
+            View name
+            <input
+              id="savedViewName"
+              type="text"
+              maxlength="80"
+              autocomplete="off"
+              placeholder="Production health"
+            />
+          </label>
+          <button type="submit">Save Current URL</button>
+        </form>
+        <ul id="savedViewsList" class="saved-view-list" aria-label="Saved views"></ul>
+        <p id="savedViewsStatus" class="saved-view-status" aria-live="polite"></p>
+      </section>
+
       <section>
         <h2>Health</h2>
         <button id="checkHealth">Check Health</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -27,6 +27,44 @@ pre {
   background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
-textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
+input, textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #333;
+  color: inherit;
+  background: transparent;
+}
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
-
+.saved-view-form { display: grid; gap: 0.75rem; margin-bottom: 1rem; }
+.saved-view-list { display: grid; gap: 0.5rem; margin: 0; padding: 0; list-style: none; }
+.saved-view-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.35rem 0.5rem;
+  align-items: center;
+  padding: 0.6rem;
+  border: 1px solid #222;
+  border-radius: 6px;
+}
+.saved-view-apply {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+.saved-view-url {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+.saved-view-delete {
+  background: transparent;
+  border: 1px solid #5a2430;
+  color: #ffccd7;
+}
+.saved-view-empty, .saved-view-status {
+  margin: 0;
+  color: var(--muted);
+}

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,23 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+
+export type SavedView = {
+  id: string;
+  name: string;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type SaveViewResult = {
+  savedView: SavedView;
+  savedViews: SavedView[];
+  mode: 'created' | 'updated';
+};
+
+const SAVED_VIEWS_STORAGE_KEY = 'os.ubq.fi:savedViews';
+const MAX_SAVED_VIEW_NAME_LENGTH = 80;
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,7 +41,179 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function readStorage(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(key: string, value: string) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Storage can be unavailable in restricted browser contexts.
+  }
+}
+
+export function normalizeSavedViewName(value: string): string | null {
+  const normalized = value.trim().replace(/\s+/g, ' ').slice(0, MAX_SAVED_VIEW_NAME_LENGTH);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isSavedView(value: unknown): value is SavedView {
+  if (typeof value !== 'object' || value === null) return false;
+  const view = value as Record<string, unknown>;
+  return (
+    typeof view.id === 'string' &&
+    view.id.length > 0 &&
+    typeof view.name === 'string' &&
+    view.name.length > 0 &&
+    typeof view.url === 'string' &&
+    view.url.length > 0 &&
+    typeof view.createdAt === 'string' &&
+    typeof view.updatedAt === 'string'
+  );
+}
+
+export function parseSavedViews(value: string | null): SavedView[] {
+  if (!value) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter(isSavedView) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getCurrentViewUrl(location: Location | URL): string {
+  return `${location.pathname}${location.search}${location.hash}`;
+}
+
+export function saveNamedView(
+  savedViews: SavedView[],
+  rawName: string,
+  url: string,
+  now = new Date(),
+): SaveViewResult | null {
+  const name = normalizeSavedViewName(rawName);
+  if (!name) return null;
+
+  const timestamp = now.toISOString();
+  const existingIndex = savedViews.findIndex((view) => view.name === name);
+
+  if (existingIndex >= 0) {
+    const existing = savedViews[existingIndex]!;
+    const savedView = { ...existing, url, updatedAt: timestamp };
+    return {
+      savedView,
+      savedViews: [
+        savedView,
+        ...savedViews.slice(0, existingIndex),
+        ...savedViews.slice(existingIndex + 1),
+      ],
+      mode: 'updated',
+    };
+  }
+
+  const savedView: SavedView = {
+    id: `view-${timestamp}-${name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+    name,
+    url,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+
+  return {
+    savedView,
+    savedViews: [savedView, ...savedViews],
+    mode: 'created',
+  };
+}
+
+export function removeSavedView(savedViews: SavedView[], id: string): SavedView[] {
+  return savedViews.filter((view) => view.id !== id);
+}
+
+function initSavedViews() {
+  const form = byId<HTMLFormElement>('savedViewForm');
+  const nameInput = byId<HTMLInputElement>('savedViewName');
+  const list = byId<HTMLUListElement>('savedViewsList');
+  const status = byId<HTMLParagraphElement>('savedViewsStatus');
+
+  let savedViews = parseSavedViews(readStorage(SAVED_VIEWS_STORAGE_KEY));
+
+  function persistAndRender(nextViews: SavedView[]) {
+    savedViews = nextViews;
+    writeStorage(SAVED_VIEWS_STORAGE_KEY, JSON.stringify(savedViews));
+    renderSavedViews();
+  }
+
+  function renderSavedViews() {
+    list.replaceChildren();
+
+    if (savedViews.length === 0) {
+      const item = document.createElement('li');
+      item.className = 'saved-view-empty';
+      item.textContent = 'No saved views yet.';
+      list.append(item);
+      return;
+    }
+
+    for (const view of savedViews) {
+      const item = document.createElement('li');
+      item.className = 'saved-view-item';
+
+      const applyButton = document.createElement('button');
+      applyButton.type = 'button';
+      applyButton.className = 'saved-view-apply';
+      applyButton.textContent = view.name;
+      applyButton.title = `Apply ${view.url}`;
+      applyButton.addEventListener('click', () => {
+        window.location.assign(view.url);
+      });
+
+      const urlText = document.createElement('span');
+      urlText.className = 'saved-view-url';
+      urlText.textContent = view.url;
+
+      const deleteButton = document.createElement('button');
+      deleteButton.type = 'button';
+      deleteButton.className = 'saved-view-delete';
+      deleteButton.textContent = 'Delete';
+      deleteButton.addEventListener('click', () => {
+        persistAndRender(removeSavedView(savedViews, view.id));
+        status.textContent = `Deleted "${view.name}".`;
+      });
+
+      item.append(applyButton, urlText, deleteButton);
+      list.append(item);
+    }
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const result = saveNamedView(savedViews, nameInput.value, getCurrentViewUrl(window.location));
+    if (!result) {
+      status.textContent = 'Enter a name before saving this view.';
+      return;
+    }
+
+    persistAndRender(result.savedViews);
+    nameInput.value = '';
+    status.textContent =
+      result.mode === 'created'
+        ? `Saved "${result.savedView.name}".`
+        : `Updated "${result.savedView.name}".`;
+  });
+
+  renderSavedViews();
+}
+
+function initApp() {
+  initSavedViews();
+
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -57,4 +248,8 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
-});
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initApp);
+}

--- a/tests/web-app.test.ts
+++ b/tests/web-app.test.ts
@@ -1,0 +1,91 @@
+import { assertEquals } from '@std/assert';
+import {
+  getCurrentViewUrl,
+  normalizeSavedViewName,
+  parseSavedViews,
+  removeSavedView,
+  saveNamedView,
+  type SavedView,
+} from '../src/web/app.ts';
+
+Deno.test('normalizeSavedViewName trims whitespace and rejects blank names', () => {
+  assertEquals(normalizeSavedViewName('  My   view  '), 'My view');
+  assertEquals(normalizeSavedViewName('   '), null);
+});
+
+Deno.test('parseSavedViews returns only well-formed saved views', () => {
+  const valid: SavedView = {
+    id: 'view-1',
+    name: 'Health',
+    url: '/?table=health',
+    createdAt: '2026-05-20T00:00:00.000Z',
+    updatedAt: '2026-05-20T00:00:00.000Z',
+  };
+
+  assertEquals(parseSavedViews('not json'), []);
+  assertEquals(parseSavedViews(JSON.stringify([valid, { name: 'missing fields' }])), [valid]);
+});
+
+Deno.test('saveNamedView creates a new saved view for the current URL', () => {
+  const result = saveNamedView(
+    [],
+    'Health check',
+    '/?table=health',
+    new Date('2026-05-20T00:00:00Z'),
+  );
+
+  assertEquals(result?.mode, 'created');
+  assertEquals(result?.savedViews.length, 1);
+  assertEquals(result?.savedView.name, 'Health check');
+  assertEquals(result?.savedView.url, '/?table=health');
+});
+
+Deno.test('saveNamedView updates an existing view with the same name', () => {
+  const existing: SavedView = {
+    id: 'view-1',
+    name: 'Health',
+    url: '/?table=health',
+    createdAt: '2026-05-20T00:00:00.000Z',
+    updatedAt: '2026-05-20T00:00:00.000Z',
+  };
+
+  const result = saveNamedView(
+    [existing],
+    'Health',
+    '/?table=health&row=latest',
+    new Date('2026-05-20T01:00:00Z'),
+  );
+
+  assertEquals(result?.mode, 'updated');
+  assertEquals(result?.savedViews.length, 1);
+  assertEquals(result?.savedView.id, existing.id);
+  assertEquals(result?.savedView.createdAt, existing.createdAt);
+  assertEquals(result?.savedView.updatedAt, '2026-05-20T01:00:00.000Z');
+  assertEquals(result?.savedView.url, '/?table=health&row=latest');
+});
+
+Deno.test('removeSavedView deletes a saved view by id', () => {
+  const views: SavedView[] = [
+    {
+      id: 'view-1',
+      name: 'Health',
+      url: '/?table=health',
+      createdAt: '2026-05-20T00:00:00.000Z',
+      updatedAt: '2026-05-20T00:00:00.000Z',
+    },
+    {
+      id: 'view-2',
+      name: 'Time',
+      url: '/?table=time',
+      createdAt: '2026-05-20T00:00:00.000Z',
+      updatedAt: '2026-05-20T00:00:00.000Z',
+    },
+  ];
+
+  assertEquals(removeSavedView(views, 'view-1'), [views[1]]);
+});
+
+Deno.test('getCurrentViewUrl keeps path, search params, and hash', () => {
+  const url = new URL('https://example.com/dashboard?table=health#row-1');
+  assertEquals(getCurrentViewUrl(url), '/dashboard?table=health#row-1');
+});


### PR DESCRIPTION
Resolves #8

/claim #8

## Summary
- add a Saved Views panel that stores the current path, query, and hash under a user-provided name in localStorage
- list saved views with apply and delete controls, and update an existing saved view when the same name is saved again
- add helper coverage for parsing stored views, saving/updating views, deleting views, and extracting the current URL state

## Validation
- `deno task test`
- `deno task build:client`
- `deno task lint`
- `deno task knip`
- `deno run -A npm:prettier@^3 --check src/web/app.ts public/index.html public/styles.css tests/web-app.test.ts`
- `git diff --check`
- Browser smoke on `http://localhost:8123`: saved `/?table=health#row-1`, added a second view, deleted it, and verified the saved-view list/localStorage updated
