### PR TITLE
feat(ui): add column filters

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,44 @@
       <h1>os.ubq.fi</h1>
       <p>Minimal Deno server with a simple UI and API.</p>
 
+      <section aria-labelledby="issuesHeading">
+        <h2 id="issuesHeading">Issues</h2>
+        <form id="filterForm" class="filter-form">
+          <label>
+            Column
+            <select id="filterColumn"></select>
+          </label>
+          <label>
+            Operator
+            <select id="filterOperator">
+              <option value="ilike">Contains</option>
+              <option value="eq">Equals</option>
+            </select>
+          </label>
+          <label>
+            Value
+            <input id="filterValue" type="text" autocomplete="off" placeholder="plugin" />
+          </label>
+          <button type="submit">Add Filter</button>
+        </form>
+        <div id="filterChips" class="filter-chips" aria-label="Active filters"></div>
+        <p id="issuesStatus" class="issues-status" aria-live="polite">Loading issues</p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Title</th>
+                <th scope="col">Repository</th>
+                <th scope="col">Status</th>
+                <th scope="col">Created</th>
+                <th scope="col">ID</th>
+              </tr>
+            </thead>
+            <tbody id="issueRows"></tbody>
+          </table>
+        </div>
+      </section>
+
       <section>
         <h2>Health</h2>
         <button id="checkHealth">Check Health</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -27,6 +27,64 @@ pre {
   background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
-textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
+input, select, textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 6px;
+  border: 1px solid #333;
+  color: inherit;
+  background: transparent;
+}
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
+.filter-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1.4fr auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-height: 2rem;
+  margin: 0.75rem 0;
+}
+.filter-chip {
+  background: #163a25;
+  border: 1px solid #2d7a4e;
+  color: #c9f4d9;
+}
+.issues-status {
+  margin: 0.5rem 0;
+  color: var(--muted);
+}
+.table-wrap {
+  overflow: auto;
+  border: 1px solid #222;
+  border-radius: 6px;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 620px;
+}
+th, td {
+  padding: 0.6rem;
+  border-bottom: 1px solid #222;
+  text-align: left;
+  vertical-align: top;
+}
+th {
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+tbody tr:last-child td {
+  border-bottom: 0;
+}
 
+@media (max-width: 720px) {
+  .filter-form {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,62 @@ import { serveDir } from '@std/http/file-server';
 const PUBLIC_DIR = Deno.env.get('PUBLIC_DIR') ?? 'public';
 const PORT = Number.parseInt(Deno.env.get('PORT') ?? '8000');
 
+type FilterOperator = 'eq' | 'ilike';
+
+type IssueRow = {
+  id: string;
+  title: string;
+  repo: string;
+  status: string;
+  created: string;
+};
+
+type AppliedFilter = {
+  column: keyof IssueRow;
+  op: FilterOperator;
+  value: string;
+};
+
+const ISSUE_ROWS: IssueRow[] = [
+  {
+    id: 'iss_1001',
+    title: 'Price label sync stalls after invoice creation',
+    repo: 'pay.ubq.fi',
+    status: 'open',
+    created: '2026-01-12',
+  },
+  {
+    id: 'iss_1002',
+    title: 'Worker startup retries hide plugin failures',
+    repo: 'os.ubq.fi',
+    status: 'review',
+    created: '2026-02-08',
+  },
+  {
+    id: 'iss_1003',
+    title: 'Command runner drops repository filter state',
+    repo: 'command-start-stop',
+    status: 'open',
+    created: '2026-03-03',
+  },
+  {
+    id: 'iss_1004',
+    title: 'Contributor reward proof export',
+    repo: 'work.ubq.fi',
+    status: 'done',
+    created: '2026-03-28',
+  },
+  {
+    id: 'iss_1005',
+    title: 'Plugin registry health card is stale',
+    repo: 'os.ubq.fi',
+    status: 'blocked',
+    created: '2026-04-16',
+  },
+];
+
+const ISSUE_FILTER_COLUMNS = new Set<keyof IssueRow>(['id', 'title', 'repo', 'status', 'created']);
+
 export async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const pathname = url.pathname;
@@ -18,6 +74,10 @@ export async function handler(req: Request): Promise<Response> {
       if (pathname === '/api/time' && req.method === 'GET') {
         const now = new Date();
         return json({ iso: now.toISOString(), epochMS: now.getTime() });
+      }
+
+      if (pathname === '/api/sb/rows' && req.method === 'GET') {
+        return rows(url.searchParams);
       }
 
       if (pathname === '/api/echo' && req.method === 'POST') {
@@ -60,6 +120,57 @@ export async function handler(req: Request): Promise<Response> {
     console.error('Request error:', err);
     return new Response('Internal Server Error', { status: 500 });
   }
+}
+
+function rows(params: URLSearchParams): Response {
+  const table = params.get('table') ?? 'issues';
+  if (table !== 'issues') {
+    return json({ error: `Unsupported table "${table}"` }, { status: 400 });
+  }
+
+  const filters = parseIssueFilters(params);
+  const rows = ISSUE_ROWS.filter((row) => matchesFilters(row, filters));
+  return json({ table, filters, rows });
+}
+
+function parseIssueFilters(params: URLSearchParams): AppliedFilter[] {
+  const filters: AppliedFilter[] = [];
+
+  for (const column of ISSUE_FILTER_COLUMNS) {
+    const raw = params.get(column);
+    if (!raw) continue;
+
+    const filter = parsePostgrestFilter(column, raw);
+    if (filter) {
+      filters.push(filter);
+    }
+  }
+
+  return filters;
+}
+
+function parsePostgrestFilter(column: keyof IssueRow, raw: string): AppliedFilter | null {
+  const separatorIndex = raw.indexOf('.');
+  if (separatorIndex <= 0) return null;
+
+  const op = raw.slice(0, separatorIndex);
+  const value = raw.slice(separatorIndex + 1).trim();
+  if ((op !== 'eq' && op !== 'ilike') || !value) return null;
+
+  return {
+    column,
+    op,
+    value: op === 'ilike' ? value.replace(/^\*|\*$/g, '') : value,
+  };
+}
+
+function matchesFilters(row: IssueRow, filters: AppliedFilter[]): boolean {
+  return filters.every((filter) => {
+    const actual = String(row[filter.column] ?? '').toLowerCase();
+    const expected = filter.value.toLowerCase();
+
+    return filter.op === 'eq' ? actual === expected : actual.includes(expected);
+  });
 }
 
 function json(data: unknown, init: ResponseInit = {}): Response {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,38 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+
+type FilterOperator = 'eq' | 'ilike';
+
+type IssueColumn = 'id' | 'title' | 'repo' | 'status' | 'created';
+
+type IssueRow = Record<IssueColumn, string>;
+
+type AppliedFilter = {
+  column: IssueColumn;
+  label: string;
+  op: FilterOperator;
+  value: string;
+};
+
+type RowsResponse = {
+  table: 'issues';
+  filters: AppliedFilter[];
+  rows: IssueRow[];
+};
+
+const FILTER_COLUMNS: { key: IssueColumn; label: string }[] = [
+  { key: 'title', label: 'Title' },
+  { key: 'repo', label: 'Repository' },
+  { key: 'status', label: 'Status' },
+  { key: 'created', label: 'Created' },
+  { key: 'id', label: 'ID' },
+];
+
+const FILTER_OPERATORS: Record<FilterOperator, string> = {
+  eq: 'equals',
+  ilike: 'contains',
+};
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,7 +56,165 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+export function buildPostgrestFilter(operator: FilterOperator, rawValue: string): string | null {
+  const value = rawValue.trim();
+  if (!value) return null;
+
+  return operator === 'ilike' ? `ilike.*${value}*` : `eq.${value}`;
+}
+
+export function parseActiveFilters(search: string): AppliedFilter[] {
+  const params = new URLSearchParams(search);
+  return FILTER_COLUMNS.flatMap((column) => {
+    const raw = params.get(column.key);
+    if (!raw) return [];
+
+    const filter = parseFilterParam(column.key, column.label, raw);
+    return filter ? [filter] : [];
+  });
+}
+
+export function removeFilterFromSearch(search: string, column: IssueColumn): string {
+  const params = new URLSearchParams(search);
+  params.delete(column);
+  return params.toString();
+}
+
+function parseFilterParam(column: IssueColumn, label: string, raw: string): AppliedFilter | null {
+  const separatorIndex = raw.indexOf('.');
+  if (separatorIndex <= 0) return null;
+
+  const op = raw.slice(0, separatorIndex);
+  const value = raw
+    .slice(separatorIndex + 1)
+    .replace(/^\*|\*$/g, '')
+    .trim();
+  if ((op !== 'eq' && op !== 'ilike') || !value) return null;
+
+  return { column, label, op, value };
+}
+
+function initFilters() {
+  const form = byId<HTMLFormElement>('filterForm');
+  const columnSelect = byId<HTMLSelectElement>('filterColumn');
+  const operatorSelect = byId<HTMLSelectElement>('filterOperator');
+  const filterInput = byId<HTMLInputElement>('filterValue');
+
+  columnSelect.replaceChildren(
+    ...FILTER_COLUMNS.map((column) => {
+      const option = document.createElement('option');
+      option.value = column.key;
+      option.textContent = column.label;
+      return option;
+    }),
+  );
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const column = columnSelect.value as IssueColumn;
+    const operator = operatorSelect.value === 'eq' ? 'eq' : 'ilike';
+    const filter = buildPostgrestFilter(operator, filterInput.value);
+    if (!filter) return;
+
+    const params = new URLSearchParams(window.location.search);
+    params.set(column, filter);
+    history.pushState(null, '', `?${params.toString()}`);
+    filterInput.value = '';
+    void loadIssueRows();
+  });
+}
+
+async function loadIssueRows() {
+  const params = new URLSearchParams(window.location.search);
+  params.set('table', 'issues');
+
+  const result = await fetchJSON(`/api/sb/rows?${params.toString()}`);
+  if (!result.ok || !isRowsResponse(result.data)) {
+    renderIssueRows([]);
+    renderFilterChips();
+    byId<HTMLParagraphElement>('issuesStatus').textContent = 'Unable to load filtered rows.';
+    return;
+  }
+
+  renderIssueRows(result.data.rows);
+  renderFilterChips();
+  byId<HTMLParagraphElement>('issuesStatus').textContent =
+    result.data.filters.length === 0
+      ? `${result.data.rows.length} issues`
+      : `${result.data.rows.length} issues match ${result.data.filters.length} filter${
+          result.data.filters.length === 1 ? '' : 's'
+        }`;
+}
+
+function renderIssueRows(rows: IssueRow[]) {
+  const tableBody = byId<HTMLTableSectionElement>('issueRows');
+  if (rows.length === 0) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = FILTER_COLUMNS.length;
+    cell.textContent = 'No matching issues.';
+    row.append(cell);
+    tableBody.replaceChildren(row);
+    return;
+  }
+
+  tableBody.replaceChildren(
+    ...rows.map((row) => {
+      const tr = document.createElement('tr');
+      tr.append(
+        tableCell(row.title),
+        tableCell(row.repo),
+        tableCell(row.status),
+        tableCell(row.created),
+        tableCell(row.id),
+      );
+      return tr;
+    }),
+  );
+}
+
+function renderFilterChips() {
+  const chips = byId<HTMLDivElement>('filterChips');
+  const filters = parseActiveFilters(window.location.search);
+  chips.replaceChildren(
+    ...filters.map((filter) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'filter-chip';
+      button.textContent = `${filter.label} ${FILTER_OPERATORS[filter.op]} ${filter.value} x`;
+      button.setAttribute(
+        'aria-label',
+        `Remove ${filter.label} ${FILTER_OPERATORS[filter.op]} ${filter.value} filter`,
+      );
+      button.addEventListener('click', () => {
+        const nextSearch = removeFilterFromSearch(window.location.search, filter.column);
+        history.pushState(null, '', nextSearch ? `?${nextSearch}` : window.location.pathname);
+        void loadIssueRows();
+      });
+      return button;
+    }),
+  );
+}
+
+function tableCell(value: string): HTMLTableCellElement {
+  const cell = document.createElement('td');
+  cell.textContent = value;
+  return cell;
+}
+
+function isRowsResponse(data: unknown): data is RowsResponse {
+  if (!data || typeof data !== 'object') return false;
+  const candidate = data as Partial<RowsResponse>;
+  return (
+    candidate.table === 'issues' &&
+    Array.isArray(candidate.filters) &&
+    Array.isArray(candidate.rows)
+  );
+}
+
+function initApp() {
+  initFilters();
+
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -57,4 +249,14 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
-});
+
+  window.addEventListener('popstate', () => {
+    void loadIssueRows();
+  });
+
+  void loadIssueRows();
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initApp);
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -18,6 +18,50 @@ Deno.test('GET /api/time returns iso timestamp', async () => {
   assertEquals(typeof data.epochMS, 'number');
 });
 
+Deno.test('GET /api/sb/rows filters issues with PostgREST eq operator', async () => {
+  const res = await handler(
+    new Request('http://localhost/api/sb/rows?table=issues&status=eq.open'),
+  );
+  assertEquals(res.status, 200);
+  const data = await res.json();
+  assertEquals(data.rows.length, 2);
+  assertEquals(data.filters, [{ column: 'status', op: 'eq', value: 'open' }]);
+  assertEquals(
+    data.rows.every((row: { status: string }) => row.status === 'open'),
+    true,
+  );
+});
+
+Deno.test('GET /api/sb/rows filters issues with PostgREST ilike operator', async () => {
+  const res = await handler(
+    new Request('http://localhost/api/sb/rows?table=issues&title=ilike.*plugin*'),
+  );
+  assertEquals(res.status, 200);
+  const data = await res.json();
+  assertEquals(data.rows.length, 2);
+  assertEquals(
+    data.rows.every((row: { title: string }) => /plugin/i.test(row.title)),
+    true,
+  );
+});
+
+Deno.test('GET /api/sb/rows combines column filters', async () => {
+  const res = await handler(
+    new Request('http://localhost/api/sb/rows?table=issues&repo=eq.os.ubq.fi&status=eq.blocked'),
+  );
+  assertEquals(res.status, 200);
+  const data = await res.json();
+  assertEquals(
+    data.rows.map((row: { id: string }) => row.id),
+    ['iss_1005'],
+  );
+});
+
+Deno.test('GET /api/sb/rows rejects unsupported tables', async () => {
+  const res = await handler(new Request('http://localhost/api/sb/rows?table=users'));
+  assertEquals(res.status, 400);
+});
+
 Deno.test('POST /api/echo returns same JSON', async () => {
   const payload = { hello: 'world' };
   const res = await handler(

--- a/tests/web-app.test.ts
+++ b/tests/web-app.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from '@std/assert';
+import {
+  buildPostgrestFilter,
+  parseActiveFilters,
+  removeFilterFromSearch,
+} from '../src/web/app.ts';
+
+Deno.test('buildPostgrestFilter creates eq and ilike expressions', () => {
+  assertEquals(buildPostgrestFilter('eq', ' open '), 'eq.open');
+  assertEquals(buildPostgrestFilter('ilike', ' plugin '), 'ilike.*plugin*');
+  assertEquals(buildPostgrestFilter('eq', '   '), null);
+});
+
+Deno.test('parseActiveFilters reads supported filters from URL search', () => {
+  assertEquals(parseActiveFilters('?status=eq.open&title=ilike.*plugin*&ignored=eq.nope'), [
+    { column: 'title', label: 'Title', op: 'ilike', value: 'plugin' },
+    { column: 'status', label: 'Status', op: 'eq', value: 'open' },
+  ]);
+});
+
+Deno.test('removeFilterFromSearch drops one column filter and keeps the rest', () => {
+  assertEquals(
+    removeFilterFromSearch('?status=eq.open&title=ilike.*plugin*', 'status'),
+    'title=ilike.*plugin*',
+  );
+});


### PR DESCRIPTION
Resolves #3

/claim #3

## Summary
- add an `/api/sb/rows` issues endpoint with PostgREST-style `eq` and `ilike` column filters
- add an Issues grid with column/operator/value controls, URL-backed filter state, and removable filter chips
- add server and frontend helper coverage for filter parsing/removal and filtered result behavior

## Validation
- `deno task test`
- `deno task build:client`
- `deno task lint`
- `deno task knip`
- `deno run -A npm:prettier@^3 --check public/index.html public/styles.css src/server.ts src/web/app.ts tests/server.test.ts tests/web-app.test.ts`
- `git diff --cached --check`
- Browser smoke on `http://localhost:8124`: added `status=eq.open`, confirmed 2 rows, reloaded with the chip/result preserved, removed it, then added `title=ilike.*plugin*` and confirmed 2 matching rows
