### PR TITLE
feat(ui): add drill-through navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,8 +34,10 @@
         </form>
         <pre id="echoOut">(submit to send)</pre>
       </section>
+
+      <section id="drillThroughExplorer" aria-label="Related record drill-through"></section>
     </main>
 
     <script type="module" defer src="/assets/app.js"></script>
   </body>
-  </html>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -4,6 +4,8 @@
   --fg: #e6e8ea;
   --accent: #7cd7ff;
   --muted: #9aa4af;
+  --panel: #11141a;
+  --line: #242a35;
 }
 
 * { box-sizing: border-box; }
@@ -30,3 +32,146 @@ pre {
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+.drill-tabs,
+.related-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.drill-tab {
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--line);
+}
+
+.drill-tab.is-active {
+  background: #1a73e8;
+  border-color: #1a73e8;
+  color: #fff;
+}
+
+.drill-filter {
+  align-items: center;
+  background: #101820;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--accent);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin: 1rem 0;
+  padding: 0.6rem 0.75rem;
+}
+
+.drill-filter button {
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+}
+
+.drill-rows {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  margin-top: 1rem;
+  overflow: auto;
+}
+
+.drill-row {
+  align-items: stretch;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  color: inherit;
+  display: grid;
+  font-weight: 500;
+  grid-template-columns: repeat(var(--drill-column-count), minmax(8rem, 1fr));
+  min-width: 100%;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+}
+
+.drill-row:last-child {
+  border-bottom: 0;
+}
+
+.drill-row span {
+  border-right: 1px solid var(--line);
+  overflow-wrap: anywhere;
+  padding: 0.65rem;
+}
+
+.drill-row span:last-child {
+  border-right: 0;
+}
+
+.drill-row:not(.drill-row-header):hover,
+.drill-row.is-selected {
+  background: #13233a;
+}
+
+.drill-row-header {
+  background: var(--panel);
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.drill-empty {
+  color: var(--muted);
+  margin: 0;
+  padding: 0.75rem;
+}
+
+.drill-details {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+.drill-details h3 {
+  font-size: 1.05rem;
+  margin: 0 0 0.75rem;
+}
+
+.drill-meta {
+  display: grid;
+  gap: 0.4rem 0.75rem;
+  grid-template-columns: minmax(6rem, max-content) 1fr;
+  margin: 0 0 1rem;
+}
+
+.drill-meta dt {
+  color: var(--muted);
+}
+
+.drill-meta dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.related-card {
+  align-items: flex-start;
+  background: #0f1824;
+  border: 1px solid var(--line);
+  color: var(--fg);
+  display: flex;
+  flex: 1 1 12rem;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-height: 4.5rem;
+  text-align: left;
+}
+
+.related-card span {
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 500;
+  overflow-wrap: anywhere;
+}

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,98 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+
+export type TableName = 'issues' | 'users' | 'plugins';
+
+export type DrillRow = Readonly<{ id: string } & Record<string, string>>;
+
+export type DrillData = Readonly<Record<TableName, readonly DrillRow[]>>;
+
+export type DrillThroughState = {
+  table: TableName;
+  filterKey?: string;
+  filterValue?: string;
+  rowId?: string;
+};
+
+export type RelatedLink = {
+  label: string;
+  description: string;
+  targetTable: TableName;
+  filterKey: string;
+  filterValue: string;
+};
+
+export const DRILL_THROUGH_DATA: DrillData = {
+  users: [
+    { id: 'usr_ada', name: 'Ada Lovelace', role: 'Protocol steward', team: 'Core' },
+    { id: 'usr_grace', name: 'Grace Hopper', role: 'Runtime owner', team: 'Infrastructure' },
+    {
+      id: 'usr_katherine',
+      name: 'Katherine Johnson',
+      role: 'Workflow analyst',
+      team: 'Operations',
+    },
+  ],
+  plugins: [
+    { id: 'plg_router', name: 'Router', category: 'Navigation', maintainerId: 'usr_ada' },
+    { id: 'plg_indexer', name: 'Indexer', category: 'Data', maintainerId: 'usr_grace' },
+    {
+      id: 'plg_scheduler',
+      name: 'Scheduler',
+      category: 'Automation',
+      maintainerId: 'usr_katherine',
+    },
+  ],
+  issues: [
+    {
+      id: 'iss_nav',
+      title: 'Add relationship drill-through',
+      status: 'Ready',
+      userId: 'usr_ada',
+      pluginId: 'plg_router',
+      repo: '0x4007/os.ubq.fi',
+    },
+    {
+      id: 'iss_queue',
+      title: 'Expose queue ownership',
+      status: 'In review',
+      userId: 'usr_katherine',
+      pluginId: 'plg_scheduler',
+      repo: '0x4007/os.ubq.fi',
+    },
+    {
+      id: 'iss_index',
+      title: 'Normalize index refresh state',
+      status: 'Open',
+      userId: 'usr_grace',
+      pluginId: 'plg_indexer',
+      repo: '0x4007/os.ubq.fi',
+    },
+    {
+      id: 'iss_docs',
+      title: 'Document router callbacks',
+      status: 'Open',
+      userId: 'usr_ada',
+      pluginId: 'plg_router',
+      repo: '0x4007/docs.ubq.fi',
+    },
+  ],
+};
+
+const TABLES: readonly TableName[] = ['issues', 'users', 'plugins'];
+
+const TABLE_LABELS: Record<TableName, string> = {
+  issues: 'Issues',
+  users: 'Users',
+  plugins: 'Plugins',
+};
+
+const TABLE_COLUMNS: Record<TableName, readonly string[]> = {
+  issues: ['id', 'title', 'status', 'userId', 'pluginId', 'repo'],
+  users: ['id', 'name', 'role', 'team'],
+  plugins: ['id', 'name', 'category', 'maintainerId'],
+};
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,7 +116,347 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function normalizeTableName(value: string | null): TableName {
+  return TABLES.find((table) => table === value) ?? 'issues';
+}
+
+function createDrillState(
+  table: TableName,
+  filterKey?: string,
+  filterValue?: string,
+  rowId?: string,
+): DrillThroughState {
+  const state: DrillThroughState = { table };
+
+  if (filterKey && filterValue !== undefined) {
+    state.filterKey = filterKey;
+    state.filterValue = filterValue;
+  }
+
+  if (rowId) {
+    state.rowId = rowId;
+  }
+
+  return state;
+}
+
+export function parseDrillThroughState(search: string | URLSearchParams): DrillThroughState {
+  const params =
+    typeof search === 'string'
+      ? new URLSearchParams(search.startsWith('?') ? search.slice(1) : search)
+      : search;
+
+  return createDrillState(
+    normalizeTableName(params.get('table')),
+    params.get('filterKey')?.trim() || undefined,
+    params.get('filterValue') ?? undefined,
+    params.get('rowId')?.trim() || undefined,
+  );
+}
+
+export function serializeDrillThroughState(state: DrillThroughState): string {
+  const params = new URLSearchParams();
+  params.set('table', state.table);
+
+  if (state.filterKey && state.filterValue !== undefined) {
+    params.set('filterKey', state.filterKey);
+    params.set('filterValue', state.filterValue);
+  }
+
+  if (state.rowId) {
+    params.set('rowId', state.rowId);
+  }
+
+  return `?${params.toString()}`;
+}
+
+export function getFilteredRows(
+  table: TableName,
+  state: DrillThroughState,
+  data: DrillData = DRILL_THROUGH_DATA,
+): readonly DrillRow[] {
+  const rows = data[table];
+
+  if (!state.filterKey || state.filterValue === undefined) {
+    return rows;
+  }
+
+  const { filterKey, filterValue } = state;
+  return rows.filter((row) => String(row[filterKey] ?? '') === filterValue);
+}
+
+export function resolveDrillThroughState(
+  state: DrillThroughState,
+  data: DrillData = DRILL_THROUGH_DATA,
+): DrillThroughState {
+  const filteredRows = getFilteredRows(state.table, state, data);
+  const selectedRow =
+    filteredRows.find((row) => row.id === state.rowId) ?? filteredRows[0] ?? data[state.table][0];
+
+  return createDrillState(state.table, state.filterKey, state.filterValue, selectedRow?.id);
+}
+
+export function getRelatedLinks(table: TableName, row: DrillRow): RelatedLink[] {
+  if (table === 'issues') {
+    const links: RelatedLink[] = [];
+
+    if (row.userId) {
+      links.push({
+        label: 'Reporter',
+        description: `Open user ${row.userId}`,
+        targetTable: 'users',
+        filterKey: 'id',
+        filterValue: row.userId,
+      });
+    }
+
+    if (row.pluginId) {
+      links.push({
+        label: 'Plugin',
+        description: `Open plugin ${row.pluginId}`,
+        targetTable: 'plugins',
+        filterKey: 'id',
+        filterValue: row.pluginId,
+      });
+    }
+
+    if (row.repo) {
+      links.push({
+        label: 'Repository issues',
+        description: `Filter issues by ${row.repo}`,
+        targetTable: 'issues',
+        filterKey: 'repo',
+        filterValue: row.repo,
+      });
+    }
+
+    return links;
+  }
+
+  if (table === 'users') {
+    return [
+      {
+        label: 'Reported issues',
+        description: `Filter issues by ${row.id}`,
+        targetTable: 'issues',
+        filterKey: 'userId',
+        filterValue: row.id,
+      },
+    ];
+  }
+
+  return [
+    {
+      label: 'Linked issues',
+      description: `Filter issues by ${row.id}`,
+      targetTable: 'issues',
+      filterKey: 'pluginId',
+      filterValue: row.id,
+    },
+  ];
+}
+
+export function applyDrillThroughLink(
+  link: RelatedLink,
+  data: DrillData = DRILL_THROUGH_DATA,
+): DrillThroughState {
+  return resolveDrillThroughState(
+    createDrillState(link.targetTable, link.filterKey, link.filterValue),
+    data,
+  );
+}
+
+function createElement<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+  options: { className?: string; text?: string } = {},
+): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tagName);
+
+  if (options.className) {
+    element.className = options.className;
+  }
+
+  if (options.text !== undefined) {
+    element.textContent = options.text;
+  }
+
+  return element;
+}
+
+function findSelectedRow(state: DrillThroughState, data: DrillData = DRILL_THROUGH_DATA): DrillRow {
+  const resolved = resolveDrillThroughState(state, data);
+  const rows = getFilteredRows(resolved.table, resolved, data);
+  const selectedRow =
+    rows.find((row) => row.id === resolved.rowId) ?? rows[0] ?? data[resolved.table][0];
+
+  if (!selectedRow) {
+    throw new Error(`No rows available for ${resolved.table}`);
+  }
+
+  return selectedRow;
+}
+
+function appendTableTabs(
+  container: HTMLElement,
+  state: DrillThroughState,
+  navigate: (nextState: DrillThroughState) => void,
+) {
+  const tabs = createElement('div', { className: 'drill-tabs' });
+
+  for (const table of TABLES) {
+    const button = createElement('button', { text: TABLE_LABELS[table] });
+    button.type = 'button';
+    button.className = table === state.table ? 'drill-tab is-active' : 'drill-tab';
+    button.setAttribute('aria-pressed', String(table === state.table));
+    button.addEventListener('click', () => navigate(resolveDrillThroughState({ table })));
+    tabs.append(button);
+  }
+
+  container.append(tabs);
+}
+
+function appendFilterSummary(
+  container: HTMLElement,
+  state: DrillThroughState,
+  navigate: (nextState: DrillThroughState) => void,
+) {
+  if (!state.filterKey || state.filterValue === undefined) {
+    return;
+  }
+
+  const summary = createElement('div', {
+    className: 'drill-filter',
+    text: `${TABLE_LABELS[state.table]} filtered by ${state.filterKey} = ${state.filterValue}`,
+  });
+  const clearButton = createElement('button', { text: 'Clear' });
+  clearButton.type = 'button';
+  clearButton.addEventListener('click', () =>
+    navigate(resolveDrillThroughState({ table: state.table })),
+  );
+  summary.append(clearButton);
+  container.append(summary);
+}
+
+function appendRows(
+  container: HTMLElement,
+  state: DrillThroughState,
+  navigate: (nextState: DrillThroughState) => void,
+) {
+  const columns = TABLE_COLUMNS[state.table];
+  const rows = getFilteredRows(state.table, state);
+  const list = createElement('div', { className: 'drill-rows' });
+  list.style.setProperty('--drill-column-count', String(columns.length));
+  const header = createElement('div', { className: 'drill-row drill-row-header' });
+
+  for (const column of columns) {
+    header.append(createElement('span', { text: column }));
+  }
+
+  list.append(header);
+
+  for (const row of rows) {
+    const button = createElement('button');
+    button.type = 'button';
+    button.className = row.id === state.rowId ? 'drill-row is-selected' : 'drill-row';
+    button.dataset.rowId = row.id;
+    button.setAttribute('aria-pressed', String(row.id === state.rowId));
+    button.addEventListener('click', () =>
+      navigate(createDrillState(state.table, state.filterKey, state.filterValue, row.id)),
+    );
+
+    for (const column of columns) {
+      button.append(createElement('span', { text: row[column] ?? '' }));
+    }
+
+    list.append(button);
+  }
+
+  if (rows.length === 0) {
+    list.append(
+      createElement('p', { className: 'drill-empty', text: 'No rows match this relationship.' }),
+    );
+  }
+
+  container.append(list);
+}
+
+function appendDetails(
+  container: HTMLElement,
+  state: DrillThroughState,
+  navigate: (nextState: DrillThroughState) => void,
+) {
+  const selectedRow = findSelectedRow(state);
+  const links = getRelatedLinks(state.table, selectedRow);
+  const details = createElement('div', { className: 'drill-details' });
+  const heading = createElement('h3', {
+    text: selectedRow.name ?? selectedRow.title ?? selectedRow.id,
+  });
+  details.append(heading);
+
+  const meta = createElement('dl', { className: 'drill-meta' });
+  for (const [key, value] of Object.entries(selectedRow)) {
+    const term = createElement('dt', { text: key });
+    const description = createElement('dd', { text: value });
+    meta.append(term, description);
+  }
+  details.append(meta);
+
+  const related = createElement('div', { className: 'related-cards' });
+  for (const link of links) {
+    const button = createElement('button', { className: 'related-card' });
+    button.type = 'button';
+    button.dataset.relatedTarget = `${link.targetTable}:${link.filterKey}:${link.filterValue}`;
+    const label = createElement('strong', { text: link.label });
+    const description = createElement('span', { text: link.description });
+    button.append(label, description);
+    button.addEventListener('click', () => navigate(applyDrillThroughLink(link)));
+    related.append(button);
+  }
+
+  details.append(related);
+  container.append(details);
+}
+
+function renderDrillThroughExplorer(
+  root: HTMLElement,
+  state: DrillThroughState,
+  navigate: (nextState: DrillThroughState) => void,
+) {
+  const resolvedState = resolveDrillThroughState(state);
+  root.replaceChildren();
+  root.append(createElement('h2', { text: 'Related records' }));
+  appendTableTabs(root, resolvedState, navigate);
+  appendFilterSummary(root, resolvedState, navigate);
+  appendRows(root, resolvedState, navigate);
+  appendDetails(root, resolvedState, navigate);
+}
+
+function initDrillThroughExplorer() {
+  const root = document.getElementById('drillThroughExplorer');
+
+  if (!root) {
+    return;
+  }
+
+  let currentState = resolveDrillThroughState(parseDrillThroughState(window.location.search));
+
+  const render = () => renderDrillThroughExplorer(root, currentState, navigate);
+
+  function navigate(nextState: DrillThroughState) {
+    currentState = resolveDrillThroughState(nextState);
+    window.history.pushState(currentState, '', serializeDrillThroughState(currentState));
+    render();
+  }
+
+  window.addEventListener('popstate', () => {
+    currentState = resolveDrillThroughState(parseDrillThroughState(window.location.search));
+    render();
+  });
+
+  render();
+}
+
+function initApiExamples() {
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -41,7 +475,7 @@ window.addEventListener('DOMContentLoaded', () => {
     show(timeOut, res);
   });
 
-  echoForm.addEventListener('submit', async (e) => {
+  echoForm.addEventListener('submit', async (e: Event) => {
     e.preventDefault();
     const bodyText = echoInput.value || '{}';
     try {
@@ -57,4 +491,11 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
-});
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => {
+    initApiExamples();
+    initDrillThroughExplorer();
+  });
+}

--- a/tests/drillthrough.test.ts
+++ b/tests/drillthrough.test.ts
@@ -1,0 +1,85 @@
+import { assertEquals, assertExists } from '@std/assert';
+import {
+  applyDrillThroughLink,
+  DRILL_THROUGH_DATA,
+  getFilteredRows,
+  getRelatedLinks,
+  parseDrillThroughState,
+  resolveDrillThroughState,
+  serializeDrillThroughState,
+} from '../src/web/app.ts';
+
+Deno.test('parseDrillThroughState reads URL-backed table, filter, and row selection', () => {
+  const state = parseDrillThroughState(
+    '?table=users&filterKey=id&filterValue=usr_ada&rowId=usr_ada',
+  );
+
+  assertEquals(state, {
+    table: 'users',
+    filterKey: 'id',
+    filterValue: 'usr_ada',
+    rowId: 'usr_ada',
+  });
+  assertEquals(
+    serializeDrillThroughState(state),
+    '?table=users&filterKey=id&filterValue=usr_ada&rowId=usr_ada',
+  );
+});
+
+Deno.test(
+  'applyDrillThroughLink filters the target table and selects the first matching row',
+  () => {
+    const issue = DRILL_THROUGH_DATA.issues[0];
+    assertExists(issue);
+    const reporterLink = getRelatedLinks('issues', issue).find((link) => link.label === 'Reporter');
+    assertExists(reporterLink);
+
+    const state = applyDrillThroughLink(reporterLink);
+
+    assertEquals(state, {
+      table: 'users',
+      filterKey: 'id',
+      filterValue: 'usr_ada',
+      rowId: 'usr_ada',
+    });
+    assertEquals(
+      getFilteredRows(state.table, state).map((row) => row.id),
+      ['usr_ada'],
+    );
+  },
+);
+
+Deno.test('repository related links stay on issues and select the first issue in that repo', () => {
+  const issue = DRILL_THROUGH_DATA.issues[0];
+  assertExists(issue);
+  const repoLink = getRelatedLinks('issues', issue).find(
+    (link) => link.label === 'Repository issues',
+  );
+  assertExists(repoLink);
+
+  const state = applyDrillThroughLink(repoLink);
+
+  assertEquals(state.table, 'issues');
+  assertEquals(state.filterKey, 'repo');
+  assertEquals(state.filterValue, '0x4007/os.ubq.fi');
+  assertEquals(state.rowId, 'iss_nav');
+});
+
+Deno.test(
+  'resolveDrillThroughState keeps history-restored filters and repairs stale row ids',
+  () => {
+    const state = resolveDrillThroughState({
+      table: 'issues',
+      filterKey: 'pluginId',
+      filterValue: 'plg_router',
+      rowId: 'missing',
+    });
+
+    assertEquals(state, {
+      table: 'issues',
+      filterKey: 'pluginId',
+      filterValue: 'plg_router',
+      rowId: 'iss_nav',
+    });
+  },
+);


### PR DESCRIPTION
Resolves #9

/claim #9

## Summary
- add URL-backed table/filter/selected-row state for the related records explorer
- add related cards that drill into users, plugins, and issues while selecting the first matching target row
- cover parsing, serialization, target selection, and stale-history repair in tests

## Validation
- deno task test
- deno task build:client
- deno task lint
- deno task knip
- deno run -A npm:prettier@^3 --check public/index.html public/styles.css src/web/app.ts tests/drillthrough.test.ts
- git diff --check
- mobile browser smoke on http://127.0.0.1:8125 (related-card click plus back/forward restore)
