### PR TITLE
feat(ui): add grid virtualization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,8 +34,10 @@
         </form>
         <pre id="echoOut">(submit to send)</pre>
       </section>
+
+      <section id="virtualGrid" aria-label="Virtualized large dataset"></section>
     </main>
 
     <script type="module" defer src="/assets/app.js"></script>
   </body>
-  </html>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -4,6 +4,8 @@
   --fg: #e6e8ea;
   --accent: #7cd7ff;
   --muted: #9aa4af;
+  --panel: #11141a;
+  --line: #242a35;
 }
 
 * { box-sizing: border-box; }
@@ -30,3 +32,71 @@ pre {
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+.virtual-status {
+  color: var(--muted);
+  margin: 0 0 0.75rem;
+}
+
+.virtual-viewport {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  height: 420px;
+  overflow: auto;
+  position: relative;
+}
+
+.virtual-list {
+  min-width: 48rem;
+}
+
+.virtual-row {
+  align-items: stretch;
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: minmax(14rem, 1.6fr) minmax(7rem, 0.8fr) minmax(6rem, 0.7fr) minmax(4rem, 0.45fr) minmax(7rem, 0.7fr) 6rem;
+  height: 44px;
+}
+
+.virtual-row.is-selected {
+  background: #13233a;
+}
+
+.virtual-cell,
+.virtual-expand {
+  align-items: center;
+  border: 0;
+  border-radius: 0;
+  border-right: 1px solid var(--line);
+  color: inherit;
+  display: flex;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  padding: 0 0.65rem;
+  text-align: left;
+}
+
+.virtual-title {
+  background: transparent;
+  color: var(--fg);
+  font-weight: 650;
+  justify-content: flex-start;
+}
+
+.virtual-title:hover,
+.virtual-expand:hover {
+  background: #172236;
+  filter: none;
+}
+
+.virtual-expand {
+  background: var(--panel);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 700;
+  justify-content: center;
+}
+
+.virtual-expand[aria-expanded="true"] {
+  background: #10251d;
+  color: #8df0b6;
+}

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,37 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+
+export type VirtualRow = {
+  id: string;
+  title: string;
+  owner: string;
+  status: string;
+  priority: string;
+  updated: string;
+};
+
+export type VirtualWindowInput = {
+  scrollTop: number;
+  viewportHeight: number;
+  rowHeight: number;
+  totalRows: number;
+  overscan: number;
+};
+
+export type VirtualWindow = {
+  start: number;
+  end: number;
+  beforeHeight: number;
+  afterHeight: number;
+};
+
+const VIRTUAL_ROW_HEIGHT = 44;
+const VIRTUAL_ROW_COUNT = 5000;
+const VIRTUAL_OVERSCAN = 6;
+const STATUSES = ['open', 'triage', 'review', 'done'] as const;
+const OWNERS = ['Core', 'Runtime', 'Operations', 'Design'] as const;
+const PRIORITIES = ['P1', 'P2', 'P3'] as const;
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,7 +55,174 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+export function createVirtualRows(count = VIRTUAL_ROW_COUNT): VirtualRow[] {
+  return Array.from({ length: count }, (_, index) => {
+    const rowNumber = index + 1;
+    const status = STATUSES[index % STATUSES.length] ?? 'open';
+    const owner = OWNERS[index % OWNERS.length] ?? 'Core';
+    const priority = PRIORITIES[index % PRIORITIES.length] ?? 'P3';
+
+    return {
+      id: `row_${String(rowNumber).padStart(5, '0')}`,
+      title: `Large dataset record ${rowNumber}`,
+      owner,
+      status,
+      priority,
+      updated: `2026-05-${String((index % 28) + 1).padStart(2, '0')}`,
+    };
+  });
+}
+
+export function getVirtualWindow(input: VirtualWindowInput): VirtualWindow {
+  const rowHeight = Math.max(1, input.rowHeight);
+  const totalRows = Math.max(0, input.totalRows);
+  const viewportHeight = Math.max(rowHeight, input.viewportHeight);
+  const overscan = Math.max(0, input.overscan);
+  const maxStart = Math.max(0, totalRows - 1);
+  const visibleRows = Math.ceil(viewportHeight / rowHeight);
+  const start = Math.min(maxStart, Math.max(0, Math.floor(input.scrollTop / rowHeight) - overscan));
+  const end = Math.min(totalRows, start + visibleRows + overscan * 2);
+
+  return {
+    start,
+    end,
+    beforeHeight: start * rowHeight,
+    afterHeight: Math.max(0, (totalRows - end) * rowHeight),
+  };
+}
+
+export function toggleExpandedRow(expandedIds: ReadonlySet<string>, rowId: string): Set<string> {
+  const next = new Set(expandedIds);
+
+  if (next.has(rowId)) {
+    next.delete(rowId);
+  } else {
+    next.add(rowId);
+  }
+
+  return next;
+}
+
+export function resolveSelectedRowId(rows: readonly VirtualRow[], selectedId?: string): string {
+  if (selectedId && rows.some((row) => row.id === selectedId)) {
+    return selectedId;
+  }
+
+  return rows[0]?.id ?? '';
+}
+
+function createElement<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+  options: { className?: string; text?: string } = {},
+): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tagName);
+
+  if (options.className) {
+    element.className = options.className;
+  }
+
+  if (options.text !== undefined) {
+    element.textContent = options.text;
+  }
+
+  return element;
+}
+
+function appendSpacer(container: HTMLElement, height: number) {
+  const spacer = createElement('div');
+  spacer.style.height = `${height}px`;
+  container.append(spacer);
+}
+
+function initVirtualGrid() {
+  const root = document.getElementById('virtualGrid');
+
+  if (!root) {
+    return;
+  }
+
+  const rows = createVirtualRows();
+  let selectedId = resolveSelectedRowId(rows);
+  let expandedIds = new Set<string>();
+  let rafId = 0;
+
+  const heading = createElement('h2', { text: 'Large dataset' });
+  const status = createElement('p', { className: 'virtual-status' });
+  const viewport = createElement('div', { className: 'virtual-viewport' });
+  const list = createElement('div', { className: 'virtual-list' });
+  viewport.append(list);
+  root.replaceChildren(heading, status, viewport);
+
+  function render() {
+    const viewportHeight = viewport.clientHeight || 420;
+    const windowState = getVirtualWindow({
+      scrollTop: viewport.scrollTop,
+      viewportHeight,
+      rowHeight: VIRTUAL_ROW_HEIGHT,
+      totalRows: rows.length,
+      overscan: VIRTUAL_OVERSCAN,
+    });
+    const visibleRows = rows.slice(windowState.start, windowState.end);
+    status.textContent = `${rows.length.toLocaleString()} rows, rendering ${windowState.start + 1}-${windowState.end}`;
+    list.replaceChildren();
+    appendSpacer(list, windowState.beforeHeight);
+
+    for (const row of visibleRows) {
+      const rowElement = createElement('div', {
+        className: row.id === selectedId ? 'virtual-row is-selected' : 'virtual-row',
+      });
+      const isExpanded = expandedIds.has(row.id);
+      rowElement.dataset.rowId = row.id;
+      rowElement.setAttribute('aria-selected', String(row.id === selectedId));
+
+      const selectButton = createElement('button', { className: 'virtual-cell virtual-title' });
+      selectButton.type = 'button';
+      selectButton.dataset.rowId = row.id;
+      selectButton.textContent = row.title;
+      selectButton.addEventListener('click', () => {
+        selectedId = row.id;
+        render();
+      });
+
+      const owner = createElement('span', { className: 'virtual-cell', text: row.owner });
+      const statusCell = createElement('span', { className: 'virtual-cell', text: row.status });
+      const priority = createElement('span', { className: 'virtual-cell', text: row.priority });
+      const updated = createElement('span', { className: 'virtual-cell', text: row.updated });
+      const expandButton = createElement('button', {
+        className: 'virtual-expand',
+        text: isExpanded ? 'Collapse' : 'Expand',
+      });
+      expandButton.type = 'button';
+      expandButton.dataset.expandId = row.id;
+      expandButton.setAttribute('aria-expanded', String(isExpanded));
+      expandButton.addEventListener('click', () => {
+        expandedIds = toggleExpandedRow(expandedIds, row.id);
+        selectedId = row.id;
+        render();
+      });
+
+      rowElement.append(selectButton, owner, statusCell, priority, updated, expandButton);
+      list.append(rowElement);
+    }
+
+    appendSpacer(list, windowState.afterHeight);
+  }
+
+  viewport.addEventListener('scroll', () => {
+    if (rafId) {
+      return;
+    }
+
+    rafId = window.requestAnimationFrame(() => {
+      rafId = 0;
+      render();
+    });
+  });
+
+  render();
+}
+
+function initApiExamples() {
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -57,4 +257,11 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
-});
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', () => {
+    initApiExamples();
+    initVirtualGrid();
+  });
+}

--- a/tests/virtual-grid.test.ts
+++ b/tests/virtual-grid.test.ts
@@ -1,0 +1,55 @@
+import { assertEquals } from '@std/assert';
+import {
+  createVirtualRows,
+  getVirtualWindow,
+  resolveSelectedRowId,
+  toggleExpandedRow,
+} from '../src/web/app.ts';
+
+Deno.test('createVirtualRows builds a deterministic 5000 row dataset', () => {
+  const rows = createVirtualRows(5000);
+
+  assertEquals(rows.length, 5000);
+  assertEquals(rows[0]?.id, 'row_00001');
+  assertEquals(rows[4999]?.id, 'row_05000');
+  assertEquals(rows[4999]?.title, 'Large dataset record 5000');
+});
+
+Deno.test('getVirtualWindow renders a small row slice with spacer heights', () => {
+  const windowState = getVirtualWindow({
+    scrollTop: 0,
+    viewportHeight: 420,
+    rowHeight: 44,
+    totalRows: 5000,
+    overscan: 6,
+  });
+
+  assertEquals(windowState.start, 0);
+  assertEquals(windowState.end, 22);
+  assertEquals(windowState.beforeHeight, 0);
+  assertEquals(windowState.afterHeight, 219_032);
+});
+
+Deno.test('getVirtualWindow clamps near the bottom of the 5000 row list', () => {
+  const windowState = getVirtualWindow({
+    scrollTop: 220_000,
+    viewportHeight: 420,
+    rowHeight: 44,
+    totalRows: 5000,
+    overscan: 6,
+  });
+
+  assertEquals(windowState.end, 5000);
+  assertEquals(windowState.afterHeight, 0);
+});
+
+Deno.test('selection and expanded row helpers preserve row ids across renders', () => {
+  const rows = createVirtualRows(3);
+  const expandedOnce = toggleExpandedRow(new Set(), 'row_00002');
+  const expandedTwice = toggleExpandedRow(expandedOnce, 'row_00002');
+
+  assertEquals(resolveSelectedRowId(rows, 'row_00003'), 'row_00003');
+  assertEquals(resolveSelectedRowId(rows, 'missing'), 'row_00001');
+  assertEquals(expandedOnce.has('row_00002'), true);
+  assertEquals(expandedTwice.has('row_00002'), false);
+});


### PR DESCRIPTION
Resolves #19

/claim #19

## Summary
- add a 5,000-row large dataset surface with spacer-based virtual window rendering
- maintain selected and expanded row state as the user scrolls away and back
- cover deterministic row generation, virtual window boundaries, and state helpers in tests

## Validation
- deno task test
- deno task build:client
- deno task lint
- deno task knip
- deno run -A npm:prettier@^3 --check public/index.html public/styles.css src/web/app.ts tests/virtual-grid.test.ts
- git diff --check
- browser smoke on http://127.0.0.1:8126 (5,000 row count, fewer than 40 rendered rows, row_02001 selected/expanded after scroll away/back)
