### PR TITLE
feat: add loading and error output states

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -4,6 +4,7 @@
   --fg: #e6e8ea;
   --accent: #7cd7ff;
   --muted: #9aa4af;
+  --danger: #ff8a8a;
 }
 
 * { box-sizing: border-box; }
@@ -30,3 +31,48 @@ pre {
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+.output {
+  min-height: 4.5rem;
+}
+
+.output--empty {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.output--error {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 55%, #1b1f2a);
+  background: color-mix(in srgb, var(--danger) 12%, #0f1115);
+}
+
+.output--loading {
+  position: relative;
+  color: transparent;
+  overflow: hidden;
+}
+
+.output--loading::before,
+.output--loading::after {
+  content: "";
+  display: block;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #202632 25%, #303949 37%, #202632 63%);
+  background-size: 400% 100%;
+  animation: skeleton-loading 1.2s ease-in-out infinite;
+}
+
+.output--loading::before {
+  width: 75%;
+  margin-bottom: 0.6rem;
+}
+
+.output--loading::after {
+  width: 45%;
+}
+
+@keyframes skeleton-loading {
+  0% { background-position: 100% 50%; }
+  100% { background-position: 0 50%; }
+}

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -16,6 +16,49 @@ function show(el: HTMLElement, value: unknown) {
   el.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
 }
 
+function isEmptyValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string') return value.trim() === '';
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'object') return Object.keys(value).length === 0;
+  return false;
+}
+
+function setPanelState(
+  el: HTMLElement,
+  state: 'empty' | 'error' | 'loading' | 'ready',
+  value?: unknown,
+) {
+  el.className = `output output--${state}`;
+  el.setAttribute('aria-busy', state === 'loading' ? 'true' : 'false');
+
+  if (state === 'loading') {
+    el.textContent = 'Loading...';
+    return;
+  }
+
+  if (state === 'empty') {
+    el.textContent = 'No data to display yet.';
+    return;
+  }
+
+  show(el, value);
+}
+
+async function loadPanel(el: HTMLElement, path: string, options: RequestInit = {}) {
+  setPanelState(el, 'loading');
+  try {
+    const res = await fetchJSON(path, options);
+    if (!res.ok) {
+      setPanelState(el, 'error', { error: 'Request failed', status: res.status, details: res.data });
+      return;
+    }
+    setPanelState(el, isEmptyValue(res.data) ? 'empty' : 'ready', res);
+  } catch (err) {
+    setPanelState(el, 'error', { error: 'Network request failed', details: String(err) });
+  }
+}
+
 function byId<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
   if (!el) throw new Error(`Missing element #${id}`);
@@ -31,14 +74,16 @@ window.addEventListener('DOMContentLoaded', () => {
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
   const echoOut = byId<HTMLPreElement>('echoOut');
 
+  setPanelState(healthOut, 'empty');
+  setPanelState(timeOut, 'empty');
+  setPanelState(echoOut, 'empty');
+
   healthBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/health');
-    show(healthOut, res);
+    await loadPanel(healthOut, '/api/health');
   });
 
   timeBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/time');
-    show(timeOut, res);
+    await loadPanel(timeOut, '/api/time');
   });
 
   echoForm.addEventListener('submit', async (e) => {
@@ -47,14 +92,13 @@ window.addEventListener('DOMContentLoaded', () => {
     try {
       JSON.parse(bodyText);
     } catch (err) {
-      show(echoOut, { error: 'Invalid JSON', details: String(err) });
+      setPanelState(echoOut, 'error', { error: 'Invalid JSON', details: String(err) });
       return;
     }
-    const res = await fetchJSON('/api/echo', {
+    await loadPanel(echoOut, '/api/echo', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: bodyText,
     });
-    show(echoOut, res);
   });
 });


### PR DESCRIPTION
## Summary
- Add reusable output panel states for empty, loading, ready, and error results
- Show skeleton placeholders while API requests are in flight
- Display muted empty messaging and inline error banners for failed requests or invalid JSON

## Verification
- `git diff --check`
- `npx -y -p typescript tsc --noEmit --target ES2019 --lib DOM,ES2019 src/web/app.ts`
- Playwright smoke test against a local static server verified:
  - initial output panels render `output--empty`
  - delayed health fetch renders `output--loading` with `aria-busy="true"`
  - successful fetch renders `output--ready`
  - invalid JSON renders `output--error`

Deno is not installed in this environment, so I could not run `deno task fmt:check` or repo tasks locally.

Closes #4