### PR TITLE
Add inline result totals chart

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,14 @@
         </form>
         <pre id="echoOut">(submit to send)</pre>
       </section>
+
+      <section>
+        <h2>Result Totals</h2>
+        <button id="showResultChart">Show Chart</button>
+        <div id="resultChart" class="chart-panel" aria-live="polite">
+          <p>Chart renders from the current loaded results.</p>
+        </div>
+      </section>
     </main>
 
     <script type="module" defer src="/assets/app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -30,3 +30,21 @@ pre {
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+.chart-panel {
+  margin-top: 0.75rem;
+  min-height: 170px;
+  background: #0f1115;
+  border: 1px solid #1b1f2a;
+  border-radius: 6px;
+  padding: 0.75rem;
+  overflow: auto;
+}
+
+.chart-panel p { margin: 0; color: var(--muted); }
+.totals-chart { display: block; width: 100%; max-width: 420px; height: auto; }
+.chart-label, .chart-value {
+  fill: var(--fg);
+  font: 600 14px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, sans-serif;
+}
+.chart-label { fill: var(--muted); }
+.chart-bar { fill: var(--accent); }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,17 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+export type ResultRowState = 'waiting' | 'loaded' | 'error';
+export type ResultRow = { id: string; label: string; state: ResultRowState };
+export type ChartBucket = { label: string; value: number };
+
+const RESULT_STATE_LABELS: Record<ResultRowState, string> = {
+  loaded: 'Loaded',
+  waiting: 'Waiting',
+  error: 'Errors',
+};
+
+const RESULT_STATE_ORDER: ResultRowState[] = ['loaded', 'waiting', 'error'];
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -16,13 +29,71 @@ function show(el: HTMLElement, value: unknown) {
   el.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
 }
 
+export function computeResultTotals(rows: readonly ResultRow[]): ChartBucket[] {
+  const totals = new Map<ResultRowState, number>();
+  for (const state of RESULT_STATE_ORDER) {
+    totals.set(state, 0);
+  }
+  for (const row of rows) {
+    totals.set(row.state, (totals.get(row.state) ?? 0) + 1);
+  }
+  return RESULT_STATE_ORDER.map((state) => ({
+    label: RESULT_STATE_LABELS[state],
+    value: totals.get(state) ?? 0,
+  }));
+}
+
+export function renderTotalsChart(buckets: readonly ChartBucket[]): string {
+  const width = 420;
+  const height = 170;
+  const paddingX = 28;
+  const chartTop = 18;
+  const barGap = 14;
+  const barHeight = 28;
+  const labelWidth = 78;
+  const maxBarWidth = width - paddingX * 2 - labelWidth - 46;
+  const maxValue = Math.max(1, ...buckets.map((bucket) => bucket.value));
+
+  const bars = buckets
+    .map((bucket, index) => {
+      const y = chartTop + index * (barHeight + barGap);
+      const barWidth = Math.round((bucket.value / maxValue) * maxBarWidth);
+      const safeLabel = escapeHTML(bucket.label);
+      return [
+        `<text x="${paddingX}" y="${y + 19}" class="chart-label">${safeLabel}</text>`,
+        `<rect x="${paddingX + labelWidth}" y="${y}" width="${barWidth}" height="${barHeight}" rx="4" class="chart-bar"></rect>`,
+        `<text x="${paddingX + labelWidth + barWidth + 10}" y="${y + 19}" class="chart-value">${bucket.value}</text>`,
+      ].join('');
+    })
+    .join('');
+
+  return `<svg class="totals-chart" role="img" aria-label="Current result totals chart" viewBox="0 0 ${width} ${height}" xmlns="http://www.w3.org/2000/svg">${bars}</svg>`;
+}
+
+function escapeHTML(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      default:
+        return '&#39;';
+    }
+  });
+}
+
 function byId<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
   if (!el) throw new Error(`Missing element #${id}`);
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+export function initApp() {
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -30,15 +101,48 @@ window.addEventListener('DOMContentLoaded', () => {
   const echoForm = byId<HTMLFormElement>('echoForm');
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
   const echoOut = byId<HTMLPreElement>('echoOut');
+  const chartBtn = byId<HTMLButtonElement>('showResultChart');
+  const chartOut = byId<HTMLDivElement>('resultChart');
+  const rows: ResultRow[] = [
+    { id: 'health', label: 'Health', state: 'waiting' },
+    { id: 'time', label: 'Time', state: 'waiting' },
+    { id: 'echo', label: 'Echo', state: 'waiting' },
+  ];
+  let chartRendered = false;
+
+  function setRowState(id: string, state: ResultRowState) {
+    const row = rows.find((item) => item.id === id);
+    if (!row) return;
+    row.state = state;
+    if (chartRendered) renderChart();
+  }
+
+  function renderChart() {
+    chartRendered = true;
+    chartOut.innerHTML = renderTotalsChart(computeResultTotals(rows));
+    chartBtn.textContent = 'Refresh Chart';
+  }
 
   healthBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/health');
-    show(healthOut, res);
+    try {
+      const res = await fetchJSON('/api/health');
+      show(healthOut, res);
+      setRowState('health', res.ok ? 'loaded' : 'error');
+    } catch (err) {
+      show(healthOut, { error: 'Request failed', details: String(err) });
+      setRowState('health', 'error');
+    }
   });
 
   timeBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/time');
-    show(timeOut, res);
+    try {
+      const res = await fetchJSON('/api/time');
+      show(timeOut, res);
+      setRowState('time', res.ok ? 'loaded' : 'error');
+    } catch (err) {
+      show(timeOut, { error: 'Request failed', details: String(err) });
+      setRowState('time', 'error');
+    }
   });
 
   echoForm.addEventListener('submit', async (e) => {
@@ -48,13 +152,26 @@ window.addEventListener('DOMContentLoaded', () => {
       JSON.parse(bodyText);
     } catch (err) {
       show(echoOut, { error: 'Invalid JSON', details: String(err) });
+      setRowState('echo', 'error');
       return;
     }
-    const res = await fetchJSON('/api/echo', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: bodyText,
-    });
-    show(echoOut, res);
+    try {
+      const res = await fetchJSON('/api/echo', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: bodyText,
+      });
+      show(echoOut, res);
+      setRowState('echo', res.ok ? 'loaded' : 'error');
+    } catch (err) {
+      show(echoOut, { error: 'Request failed', details: String(err) });
+      setRowState('echo', 'error');
+    }
   });
-});
+
+  chartBtn.addEventListener('click', renderChart);
+}
+
+if (typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initApp);
+}

--- a/tests/web-app.test.ts
+++ b/tests/web-app.test.ts
@@ -1,0 +1,29 @@
+import { assertEquals, assertStringIncludes } from '@std/assert';
+import { computeResultTotals, renderTotalsChart, type ResultRow } from '../src/web/app.ts';
+
+Deno.test('computeResultTotals counts current result row states', () => {
+  const rows: ResultRow[] = [
+    { id: 'health', label: 'Health', state: 'loaded' },
+    { id: 'time', label: 'Time', state: 'waiting' },
+    { id: 'echo', label: 'Echo', state: 'error' },
+  ];
+
+  assertEquals(computeResultTotals(rows), [
+    { label: 'Loaded', value: 1 },
+    { label: 'Waiting', value: 1 },
+    { label: 'Errors', value: 1 },
+  ]);
+});
+
+Deno.test('renderTotalsChart emits an inline SVG from computed totals', () => {
+  const svg = renderTotalsChart([
+    { label: 'Loaded', value: 2 },
+    { label: 'Waiting', value: 1 },
+    { label: 'Errors & warnings', value: 0 },
+  ]);
+
+  assertStringIncludes(svg, '<svg');
+  assertStringIncludes(svg, 'role="img"');
+  assertStringIncludes(svg, '>2</text>');
+  assertStringIncludes(svg, 'Errors &amp; warnings');
+});


### PR DESCRIPTION
Fixes #17
/claim #17

## Summary
- Adds a lazy-rendered inline SVG chart for current UI result rows.
- Tracks the existing Health, Time, and Echo result states in client memory and updates the chart from those rows only.
- Keeps the chart path free of additional network requests; API calls still happen only from the existing result buttons/forms.
- Adds focused tests for result-total computation and SVG output escaping.

## Verification
- npx --yes deno@2.7.14 task test
- npx --yes deno@2.7.14 check --config deno.json src/web/app.ts tests/web-app.test.ts
- npx --yes deno@2.7.14 run -A npm:prettier@^3 --check src/web/app.ts public/index.html public/styles.css tests/web-app.test.ts
- npx --yes deno@2.7.14 task lint
- npx --yes deno@2.7.14 task knip
- npx --yes deno@2.7.14 task build:client
- git diff --check
- Browser smoke at http://127.0.0.1:8000/: chart initially showed Loaded 0 / Waiting 3 / Errors 0, then after successful Health, Time, and Echo requests updated to Loaded 3 / Waiting 0 / Errors 0 with one inline SVG chart.

## Bounty Info
- Preferred payment method: to be provided privately after acceptance.
