### PR TITLE
feat(ui): add loading empty error states

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,13 +14,21 @@
       <section>
         <h2>Health</h2>
         <button id="checkHealth">Check Health</button>
-        <pre id="healthOut">(click to load)</pre>
+        <div id="healthState" class="state-panel is-empty" aria-live="polite">
+          <strong>No health check yet</strong>
+          <span>Run the request to load the latest API health response.</span>
+        </div>
+        <pre id="healthOut" hidden></pre>
       </section>
 
       <section>
         <h2>Time</h2>
         <button id="getTime">Get Time</button>
-        <pre id="timeOut">(click to load)</pre>
+        <div id="timeState" class="state-panel is-empty" aria-live="polite">
+          <strong>No time response yet</strong>
+          <span>Request the server time to populate this panel.</span>
+        </div>
+        <pre id="timeOut" hidden></pre>
       </section>
 
       <section>
@@ -32,7 +40,11 @@
           </label>
           <button type="submit">POST /api/echo</button>
         </form>
-        <pre id="echoOut">(submit to send)</pre>
+        <div id="echoState" class="state-panel is-empty" aria-live="polite">
+          <strong>No echo response yet</strong>
+          <span>Submit a JSON payload to see the echoed response.</span>
+        </div>
+        <pre id="echoOut" hidden></pre>
       </section>
     </main>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -4,6 +4,11 @@
   --fg: #e6e8ea;
   --accent: #7cd7ff;
   --muted: #9aa4af;
+  --panel: #0f1115;
+  --panel-border: #1b1f2a;
+  --error: #ff8a8a;
+  --error-bg: #2a1418;
+  --error-border: #6f2a33;
 }
 
 * { box-sizing: border-box; }
@@ -24,9 +29,69 @@ button {
 }
 button:hover { filter: brightness(1.05); }
 pre {
-  background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
+  background: var(--panel); border: 1px solid var(--panel-border); padding: 0.75rem; border-radius: 6px;
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
+pre[hidden] { display: none; }
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 
+.state-panel {
+  display: grid;
+  gap: 0.35rem;
+  margin-top: 0.75rem;
+  min-height: 5.5rem;
+  padding: 0.75rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--muted);
+}
+
+.state-panel[hidden] { display: none; }
+.state-panel strong { color: var(--fg); }
+.state-panel span { display: block; }
+
+.state-panel.is-loading {
+  color: var(--fg);
+}
+
+.state-panel.is-error {
+  border-color: var(--error-border);
+  background: var(--error-bg);
+  color: var(--fg);
+}
+
+.state-panel.is-error strong {
+  color: var(--error);
+}
+
+.retry-button {
+  justify-self: start;
+  margin-top: 0.35rem;
+  background: transparent;
+  border: 1px solid var(--error);
+  color: var(--fg);
+}
+
+.skeleton-stack {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.skeleton-line {
+  height: 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #1b1f2a 0%, #2d3442 45%, #1b1f2a 90%);
+  background-size: 220% 100%;
+  animation: skeleton-pulse 1.2s ease-in-out infinite;
+}
+
+.skeleton-line:nth-child(2) { width: 82%; }
+.skeleton-line:nth-child(3) { width: 58%; }
+
+@keyframes skeleton-pulse {
+  from { background-position: 100% 0; }
+  to { background-position: -100% 0; }
+}

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,14 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+export type RequestState = 'empty' | 'loading' | 'success' | 'error';
+export type StatusView = {
+  title: string;
+  message: string;
+  className: string;
+  busy: boolean;
+  showRetry: boolean;
+};
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -16,45 +26,200 @@ function show(el: HTMLElement, value: unknown) {
   el.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
 }
 
+export function getStatusView(state: RequestState, label: string, details = ''): StatusView {
+  switch (state) {
+    case 'empty':
+      return {
+        title: `No ${label.toLowerCase()} response yet`,
+        message: 'Run the request to populate this panel.',
+        className: 'is-empty',
+        busy: false,
+        showRetry: false,
+      };
+    case 'loading':
+      return {
+        title: `Loading ${label.toLowerCase()}...`,
+        message: 'Waiting for the server response.',
+        className: 'is-loading',
+        busy: true,
+        showRetry: false,
+      };
+    case 'error':
+      return {
+        title: `${label} request failed`,
+        message: details || 'The request did not complete. Try again.',
+        className: 'is-error',
+        busy: false,
+        showRetry: true,
+      };
+    case 'success':
+      return {
+        title: `${label} loaded`,
+        message: 'Response loaded successfully.',
+        className: 'is-success',
+        busy: false,
+        showRetry: false,
+      };
+  }
+}
+
 function byId<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
   if (!el) throw new Error(`Missing element #${id}`);
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function renderState(
+  stateEl: HTMLElement,
+  outputEl: HTMLElement,
+  view: StatusView,
+  onRetry?: () => void,
+) {
+  outputEl.hidden = view.className !== 'is-success';
+  stateEl.hidden = view.className === 'is-success';
+  stateEl.className = `state-panel ${view.className}`;
+  stateEl.setAttribute('aria-busy', String(view.busy));
+  stateEl.replaceChildren();
+
+  const title = document.createElement('strong');
+  title.textContent = view.title;
+  stateEl.append(title);
+
+  const message = document.createElement('span');
+  message.textContent = view.message;
+  stateEl.append(message);
+
+  if (view.busy) {
+    const stack = document.createElement('div');
+    stack.className = 'skeleton-stack';
+    stack.setAttribute('aria-hidden', 'true');
+    for (let index = 0; index < 3; index += 1) {
+      const line = document.createElement('div');
+      line.className = 'skeleton-line';
+      stack.append(line);
+    }
+    stateEl.append(stack);
+  }
+
+  if (view.showRetry && onRetry) {
+    const retry = document.createElement('button');
+    retry.type = 'button';
+    retry.className = 'retry-button';
+    retry.textContent = 'Retry';
+    retry.addEventListener('click', onRetry);
+    stateEl.append(retry);
+  }
+}
+
+function renderEmptyState(stateEl: HTMLElement, outputEl: HTMLElement, label: string) {
+  renderState(stateEl, outputEl, getStatusView('empty', label));
+}
+
+export function initApp() {
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
+  const healthState = byId<HTMLDivElement>('healthState');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
+  const timeState = byId<HTMLDivElement>('timeState');
   const timeOut = byId<HTMLPreElement>('timeOut');
   const echoForm = byId<HTMLFormElement>('echoForm');
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
+  const echoState = byId<HTMLDivElement>('echoState');
   const echoOut = byId<HTMLPreElement>('echoOut');
 
-  healthBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/health');
-    show(healthOut, res);
-  });
+  renderEmptyState(healthState, healthOut, 'Health');
+  renderEmptyState(timeState, timeOut, 'Time');
+  renderEmptyState(echoState, echoOut, 'Echo');
 
-  timeBtn.addEventListener('click', async () => {
-    const res = await fetchJSON('/api/time');
-    show(timeOut, res);
-  });
+  async function loadHealth() {
+    renderState(healthState, healthOut, getStatusView('loading', 'Health'));
+    try {
+      const res = await fetchJSON('/api/health');
+      if (!res.ok) {
+        renderState(
+          healthState,
+          healthOut,
+          getStatusView('error', 'Health', `Server returned HTTP ${res.status}.`),
+          loadHealth,
+        );
+        return;
+      }
+      show(healthOut, res);
+      renderState(healthState, healthOut, getStatusView('success', 'Health'));
+    } catch (err) {
+      renderState(
+        healthState,
+        healthOut,
+        getStatusView('error', 'Health', String(err)),
+        loadHealth,
+      );
+    }
+  }
 
-  echoForm.addEventListener('submit', async (e) => {
-    e.preventDefault();
+  async function loadTime() {
+    renderState(timeState, timeOut, getStatusView('loading', 'Time'));
+    try {
+      const res = await fetchJSON('/api/time');
+      if (!res.ok) {
+        renderState(
+          timeState,
+          timeOut,
+          getStatusView('error', 'Time', `Server returned HTTP ${res.status}.`),
+          loadTime,
+        );
+        return;
+      }
+      show(timeOut, res);
+      renderState(timeState, timeOut, getStatusView('success', 'Time'));
+    } catch (err) {
+      renderState(timeState, timeOut, getStatusView('error', 'Time', String(err)), loadTime);
+    }
+  }
+
+  async function submitEcho() {
     const bodyText = echoInput.value || '{}';
+    renderState(echoState, echoOut, getStatusView('loading', 'Echo'));
     try {
       JSON.parse(bodyText);
     } catch (err) {
-      show(echoOut, { error: 'Invalid JSON', details: String(err) });
+      renderState(
+        echoState,
+        echoOut,
+        getStatusView('error', 'Echo', `Invalid JSON: ${String(err)}`),
+        submitEcho,
+      );
       return;
     }
-    const res = await fetchJSON('/api/echo', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: bodyText,
-    });
-    show(echoOut, res);
+    try {
+      const res = await fetchJSON('/api/echo', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: bodyText,
+      });
+      if (!res.ok) {
+        renderState(
+          echoState,
+          echoOut,
+          getStatusView('error', 'Echo', `Server returned HTTP ${res.status}.`),
+          submitEcho,
+        );
+        return;
+      }
+      show(echoOut, res);
+      renderState(echoState, echoOut, getStatusView('success', 'Echo'));
+    } catch (err) {
+      renderState(echoState, echoOut, getStatusView('error', 'Echo', String(err)), submitEcho);
+    }
+  }
+
+  healthBtn.addEventListener('click', loadHealth);
+  timeBtn.addEventListener('click', loadTime);
+  echoForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    void submitEcho();
   });
-});
+}
+
+if (typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initApp);
+}

--- a/tests/web-app.test.ts
+++ b/tests/web-app.test.ts
@@ -1,0 +1,32 @@
+import { assertEquals } from '@std/assert';
+import { getStatusView } from '../src/web/app.ts';
+
+Deno.test('getStatusView describes empty panels without retry', () => {
+  assertEquals(getStatusView('empty', 'Health'), {
+    title: 'No health response yet',
+    message: 'Run the request to populate this panel.',
+    className: 'is-empty',
+    busy: false,
+    showRetry: false,
+  });
+});
+
+Deno.test('getStatusView marks loading panels as busy skeleton states', () => {
+  assertEquals(getStatusView('loading', 'Time'), {
+    title: 'Loading time...',
+    message: 'Waiting for the server response.',
+    className: 'is-loading',
+    busy: true,
+    showRetry: false,
+  });
+});
+
+Deno.test('getStatusView exposes retryable error banners', () => {
+  assertEquals(getStatusView('error', 'Echo', 'Invalid JSON'), {
+    title: 'Echo request failed',
+    message: 'Invalid JSON',
+    className: 'is-error',
+    busy: false,
+    showRetry: true,
+  });
+});


### PR DESCRIPTION
Fixes #4
/claim #4

Summary
- Adds explicit empty-state panels for Health, Time, and Echo before any request runs.
- Shows an aria-busy loading state with skeleton lines while requests are in flight.
- Replaces failed requests and invalid JSON with a retryable error panel instead of leaving stale output.
- Keeps successful responses in the existing preformatted output area.

Verification
- npx --yes deno@2.7.14 task test
- npx --yes deno@2.7.14 check --config deno.json src/web/app.ts tests/web-app.test.ts
- npx --yes deno@2.7.14 run -A npm:prettier@^3 --check public/index.html public/styles.css src/web/app.ts tests/web-app.test.ts
- npx --yes deno@2.7.14 task build:client
- npx --yes deno@2.7.14 task lint
- npx --yes deno@2.7.14 task knip
- git diff --check
- Browser smoke: initial empty panels visible, Health success reveals JSON output, invalid Echo JSON shows an error panel with Retry.

Bounty Info
Preferred payment method: to be provided privately after acceptance.