### PR TITLE
feat(ui): add persisted theme tokens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,8 +8,15 @@
   </head>
   <body>
     <main>
-      <h1>os.ubq.fi</h1>
-      <p>Minimal Deno server with a simple UI and API.</p>
+      <header class="app-header">
+        <div>
+          <h1>os.ubq.fi</h1>
+          <p>Minimal Deno server with a simple UI and API.</p>
+        </div>
+        <button id="themeToggle" class="theme-toggle" type="button" aria-pressed="false">
+          Light theme
+        </button>
+      </header>
 
       <section>
         <h2>Health</h2>
@@ -38,4 +45,4 @@
 
     <script type="module" defer src="/assets/app.js"></script>
   </body>
-  </html>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,32 +1,83 @@
 :root {
-  color-scheme: light dark;
-  --bg: #0b0c0f;
-  --fg: #e6e8ea;
+  color-scheme: dark;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --font-body: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial,
+    sans-serif;
+  --bg: #101114;
+  --surface: #171a20;
+  --surface-strong: #20242d;
+  --border: #2d3442;
+  --fg: #e7eaee;
   --accent: #7cd7ff;
-  --muted: #9aa4af;
+  --accent-strong: #1a73e8;
+  --muted: #a8b0ba;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f7f8fa;
+  --surface: #ffffff;
+  --surface-strong: #eef2f6;
+  --border: #cdd5df;
+  --fg: #151922;
+  --accent: #005f8f;
+  --accent-strong: #1463d9;
+  --muted: #53606f;
 }
 
 * { box-sizing: border-box; }
 html, body { height: 100%; margin: 0; }
 body {
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: var(--font-body);
   line-height: 1.5;
   background: var(--bg);
   color: var(--fg);
 }
-main { max-width: 720px; margin: 3rem auto; padding: 0 1rem; }
-h1 { font-size: 1.6rem; margin: 0 0 1rem; }
-h2 { font-size: 1.2rem; margin: 2rem 0 0.5rem; }
-section { padding: 1rem; border: 1px solid #222; border-radius: 8px; }
+main { max-width: 720px; margin: 3rem auto; padding: 0 var(--space-4); }
+h1 { font-size: 1.6rem; margin: 0 0 var(--space-2); }
+h2 { font-size: 1.2rem; margin: var(--space-8) 0 var(--space-2); }
+.app-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+.app-header p { margin: 0; color: var(--muted); }
+section {
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+}
 button {
-  background: #1a73e8; color: white; border: none; border-radius: 6px; cursor: pointer;
-  padding: 0.5rem 0.75rem; font-weight: 600; letter-spacing: 0.2px;
+  background: var(--accent-strong); color: white; border: none; border-radius: var(--radius-sm); cursor: pointer;
+  padding: var(--space-2) var(--space-3); font-weight: 600; letter-spacing: 0.2px;
 }
 button:hover { filter: brightness(1.05); }
+.theme-toggle {
+  flex: 0 0 auto;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  color: var(--fg);
+}
 pre {
-  background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
+  background: var(--surface-strong); border: 1px solid var(--border); padding: var(--space-3); border-radius: var(--radius-sm);
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
-textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
-label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
-
+textarea {
+  width: 100%;
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  color: inherit;
+  background: var(--surface);
+}
+label { display: block; margin-bottom: var(--space-2); color: var(--muted); }

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,33 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+export type Theme = 'dark' | 'light';
+
+const THEME_STORAGE_KEY = 'os.ubq.fi.theme';
+const THEME_COOKIE_NAME = 'os_ubq_fi_theme';
+
+function getThemeStorage(): Storage | undefined {
+  try {
+    return globalThis.window?.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+function readThemeCookie(): Theme | undefined {
+  if (typeof document === 'undefined') return undefined;
+  const value = document.cookie
+    .split(';')
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith(`${THEME_COOKIE_NAME}=`))
+    ?.split('=')[1];
+  return value === 'light' || value === 'dark' ? value : undefined;
+}
+
+function writeThemeCookie(theme: Theme) {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${THEME_COOKIE_NAME}=${theme}; path=/; max-age=31536000; SameSite=Lax`;
+}
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -16,13 +45,36 @@ function show(el: HTMLElement, value: unknown) {
   el.textContent = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
 }
 
+export function nextTheme(current: Theme): Theme {
+  return current === 'dark' ? 'light' : 'dark';
+}
+
+export function themeButtonLabel(theme: Theme): string {
+  return theme === 'dark' ? 'Light theme' : 'Dark theme';
+}
+
+function readStoredTheme(): Theme {
+  const stored = getThemeStorage()?.getItem(THEME_STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') return stored;
+  return readThemeCookie() ?? 'dark';
+}
+
+function applyTheme(theme: Theme, toggle: HTMLButtonElement) {
+  document.documentElement.dataset.theme = theme;
+  toggle.textContent = themeButtonLabel(theme);
+  toggle.setAttribute('aria-pressed', String(theme === 'light'));
+  getThemeStorage()?.setItem(THEME_STORAGE_KEY, theme);
+  writeThemeCookie(theme);
+}
+
 function byId<T extends HTMLElement>(id: string): T {
   const el = document.getElementById(id);
   if (!el) throw new Error(`Missing element #${id}`);
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+export function initApp() {
+  const themeToggle = byId<HTMLButtonElement>('themeToggle');
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -30,6 +82,14 @@ window.addEventListener('DOMContentLoaded', () => {
   const echoForm = byId<HTMLFormElement>('echoForm');
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
   const echoOut = byId<HTMLPreElement>('echoOut');
+  let activeTheme = readStoredTheme();
+
+  applyTheme(activeTheme, themeToggle);
+
+  themeToggle.addEventListener('click', () => {
+    activeTheme = nextTheme(activeTheme);
+    applyTheme(activeTheme, themeToggle);
+  });
 
   healthBtn.addEventListener('click', async () => {
     const res = await fetchJSON('/api/health');
@@ -57,4 +117,8 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
-});
+}
+
+if (typeof document !== 'undefined') {
+  globalThis.addEventListener('DOMContentLoaded', initApp);
+}

--- a/tests/web-app.test.ts
+++ b/tests/web-app.test.ts
@@ -1,0 +1,16 @@
+import { assertEquals } from '@std/assert';
+import { initApp, nextTheme, themeButtonLabel } from '../src/web/app.ts';
+
+Deno.test('nextTheme toggles between dark and light themes', () => {
+  assertEquals(nextTheme('dark'), 'light');
+  assertEquals(nextTheme('light'), 'dark');
+});
+
+Deno.test('themeButtonLabel describes the next available theme', () => {
+  assertEquals(themeButtonLabel('dark'), 'Light theme');
+  assertEquals(themeButtonLabel('light'), 'Dark theme');
+});
+
+Deno.test('initApp is importable outside a browser document', () => {
+  assertEquals(typeof initApp, 'function');
+});


### PR DESCRIPTION
Fixes #20
/claim #20

Summary
- Adds spacing, radius, typography, surface, border, and color design tokens.
- Refactors the existing UI shell, sections, controls, pre blocks, and textarea styling to use tokens.
- Adds a persisted dark/light theme toggle with accessible pressed state.
- Uses localStorage with a cookie fallback so the selected theme survives reloads.

Verification
- npx --yes deno@2.7.14 task test
- npx --yes deno@2.7.14 check --config deno.json src/web/app.ts tests/web-app.test.ts
- npx --yes deno@2.7.14 run -A npm:prettier@^3 --check public/index.html public/styles.css src/web/app.ts tests/web-app.test.ts
- npx --yes deno@2.7.14 task build:client
- npx --yes deno@2.7.14 task lint
- npx --yes deno@2.7.14 task knip
- git diff --check
- Browser smoke: default dark theme, toggle switches to light, reload keeps light selected.

Bounty Info
Preferred payment method: to be provided privately after acceptance.