### PR TITLE
feat(ui): add sortable row headers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,44 @@
       </section>
 
       <section>
+        <h2>Rows</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col" data-sort-column="service">
+                  <button class="sort-header" type="button" data-sort-key="service">
+                    Service <span class="sort-indicator" data-sort-indicator></span>
+                  </button>
+                </th>
+                <th scope="col" data-sort-column="status">
+                  <button class="sort-header" type="button" data-sort-key="status">
+                    Status <span class="sort-indicator" data-sort-indicator></span>
+                  </button>
+                </th>
+                <th scope="col" data-sort-column="latencyMS">
+                  <button class="sort-header" type="button" data-sort-key="latencyMS">
+                    Latency <span class="sort-indicator" data-sort-indicator></span>
+                  </button>
+                </th>
+                <th scope="col" data-sort-column="updatedAt">
+                  <button class="sort-header" type="button" data-sort-key="updatedAt">
+                    Updated <span class="sort-indicator" data-sort-indicator></span>
+                  </button>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="rowsBody">
+              <tr>
+                <td colspan="4">Loading rows...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p id="rowsStatus" class="sr-only" aria-live="polite"></p>
+      </section>
+
+      <section>
         <h2>Echo</h2>
         <form id="echoForm">
           <label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -27,6 +27,30 @@ pre {
   background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
+.table-wrap { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 0.5rem; border-bottom: 1px solid #222; text-align: left; }
+th { color: var(--muted); font-size: 0.85rem; }
+.sort-header {
+  width: 100%;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  text-align: left;
+}
+.sort-header:hover { color: var(--accent); filter: none; }
+.sort-indicator { color: var(--accent); font-size: 0.8rem; }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,19 @@ import { serveDir } from '@std/http/file-server';
 const PUBLIC_DIR = Deno.env.get('PUBLIC_DIR') ?? 'public';
 const PORT = Number.parseInt(Deno.env.get('PORT') ?? '8000');
 
+type SortKey = 'service' | 'status' | 'latencyMS' | 'updatedAt';
+type SortOrder = 'asc' | 'desc';
+type SBRow = { service: string; status: string; latencyMS: number; updatedAt: string };
+
+const SORT_KEYS: SortKey[] = ['service', 'status', 'latencyMS', 'updatedAt'];
+const DEFAULT_SORT_KEY: SortKey = 'service';
+const DEFAULT_SORT_ORDER: SortOrder = 'asc';
+const SB_ROWS: SBRow[] = [
+  { service: 'api', status: 'ok', latencyMS: 34, updatedAt: '2026-06-03T02:10:00.000Z' },
+  { service: 'worker', status: 'queued', latencyMS: 88, updatedAt: '2026-06-03T02:13:00.000Z' },
+  { service: 'web', status: 'ok', latencyMS: 21, updatedAt: '2026-06-03T02:11:00.000Z' },
+];
+
 export async function handler(req: Request): Promise<Response> {
   const url = new URL(req.url);
   const pathname = url.pathname;
@@ -18,6 +31,12 @@ export async function handler(req: Request): Promise<Response> {
       if (pathname === '/api/time' && req.method === 'GET') {
         const now = new Date();
         return json({ iso: now.toISOString(), epochMS: now.getTime() });
+      }
+
+      if (pathname === '/api/sb/rows' && req.method === 'GET') {
+        const sort = readSortKey(url.searchParams.get('sort'));
+        const order = readSortOrder(url.searchParams.get('order'));
+        return json({ sort, order, rows: sortRows(SB_ROWS, sort, order) });
       }
 
       if (pathname === '/api/echo' && req.method === 'POST') {
@@ -60,6 +79,26 @@ export async function handler(req: Request): Promise<Response> {
     console.error('Request error:', err);
     return new Response('Internal Server Error', { status: 500 });
   }
+}
+
+function readSortKey(value: string | null): SortKey {
+  return SORT_KEYS.includes(value as SortKey) ? (value as SortKey) : DEFAULT_SORT_KEY;
+}
+
+function readSortOrder(value: string | null): SortOrder {
+  return value === 'desc' ? 'desc' : DEFAULT_SORT_ORDER;
+}
+
+export function sortRows(rows: SBRow[], sort: SortKey, order: SortOrder): SBRow[] {
+  const direction = order === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const aValue = a[sort];
+    const bValue = b[sort];
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return (aValue - bValue) * direction;
+    }
+    return String(aValue).localeCompare(String(bValue)) * direction;
+  });
 }
 
 function json(data: unknown, init: ResponseInit = {}): Response {

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,41 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+export type SortKey = 'service' | 'status' | 'latencyMS' | 'updatedAt';
+export type SortOrder = 'asc' | 'desc';
+
+type SortState = { key: SortKey; order: SortOrder };
+type SBRow = { service: string; status: string; latencyMS: number; updatedAt: string };
+
+const DEFAULT_SORT: SortState = { key: 'service', order: 'asc' };
+const SORT_KEYS: SortKey[] = ['service', 'status', 'latencyMS', 'updatedAt'];
+
+function isSortKey(value: string | null): value is SortKey {
+  return SORT_KEYS.includes(value as SortKey);
+}
+
+function isSortOrder(value: string | null): value is SortOrder {
+  return value === 'asc' || value === 'desc';
+}
+
+export function readSortState(params: URLSearchParams): SortState {
+  const key = params.get('sort');
+  const order = params.get('order');
+  return {
+    key: isSortKey(key) ? key : DEFAULT_SORT.key,
+    order: isSortOrder(order) ? order : DEFAULT_SORT.order,
+  };
+}
+
+export function nextSortState(current: SortState, key: SortKey): SortState {
+  if (current.key !== key) return { key, order: 'asc' };
+  return { key, order: current.order === 'asc' ? 'desc' : 'asc' };
+}
+
+export function rowsURL(state: SortState): string {
+  const params = new URLSearchParams({ sort: state.key, order: state.order });
+  return `/api/sb/rows?${params.toString()}`;
+}
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,7 +59,48 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function renderRows(rowsBody: HTMLTableSectionElement, rows: SBRow[]) {
+  rowsBody.replaceChildren(
+    ...rows.map((row) => {
+      const tr = document.createElement('tr');
+      const service = document.createElement('td');
+      const status = document.createElement('td');
+      const latency = document.createElement('td');
+      const updated = document.createElement('td');
+
+      service.textContent = row.service;
+      status.textContent = row.status;
+      latency.textContent = `${row.latencyMS} ms`;
+      updated.textContent = new Date(row.updatedAt).toLocaleString();
+      tr.append(service, status, latency, updated);
+      return tr;
+    }),
+  );
+}
+
+function renderSortIndicators(headers: NodeListOf<HTMLButtonElement>, state: SortState) {
+  for (const header of headers) {
+    const key = header.dataset.sortKey as SortKey;
+    const th = header.closest('th');
+    const indicator = header.querySelector<HTMLElement>('[data-sort-indicator]');
+    const isActive = key === state.key;
+    header.setAttribute('aria-pressed', String(isActive));
+    th?.setAttribute(
+      'aria-sort',
+      isActive ? (state.order === 'asc' ? 'ascending' : 'descending') : 'none',
+    );
+    if (indicator) indicator.textContent = isActive ? `(${state.order})` : '';
+  }
+}
+
+function replaceURLSortState(state: SortState) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('sort', state.key);
+  url.searchParams.set('order', state.order);
+  window.history.replaceState(null, '', url);
+}
+
+export function initApp() {
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -30,6 +108,24 @@ window.addEventListener('DOMContentLoaded', () => {
   const echoForm = byId<HTMLFormElement>('echoForm');
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
   const echoOut = byId<HTMLPreElement>('echoOut');
+  const rowsBody = byId<HTMLTableSectionElement>('rowsBody');
+  const rowsStatus = byId<HTMLElement>('rowsStatus');
+  const sortHeaders = document.querySelectorAll<HTMLButtonElement>('[data-sort-key]');
+  let sortState = readSortState(new URLSearchParams(window.location.search));
+
+  async function loadRows() {
+    renderSortIndicators(sortHeaders, sortState);
+    rowsStatus.textContent = `Loading rows sorted by ${sortState.key} ${sortState.order}`;
+    const res = await fetchJSON(rowsURL(sortState));
+    if (!res.ok || typeof res.data !== 'object' || res.data === null || !('rows' in res.data)) {
+      rowsBody.innerHTML = '<tr><td colspan="4">Unable to load rows.</td></tr>';
+      rowsStatus.textContent = 'Unable to load rows';
+      return;
+    }
+    const { rows } = res.data as { rows: SBRow[] };
+    renderRows(rowsBody, rows);
+    rowsStatus.textContent = `Rows sorted by ${sortState.key} ${sortState.order}`;
+  }
 
   healthBtn.addEventListener('click', async () => {
     const res = await fetchJSON('/api/health');
@@ -57,4 +153,18 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
-});
+
+  for (const header of sortHeaders) {
+    header.addEventListener('click', () => {
+      sortState = nextSortState(sortState, header.dataset.sortKey as SortKey);
+      replaceURLSortState(sortState);
+      void loadRows();
+    });
+  }
+
+  void loadRows();
+}
+
+if (typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initApp);
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -18,6 +18,18 @@ Deno.test('GET /api/time returns iso timestamp', async () => {
   assertEquals(typeof data.epochMS, 'number');
 });
 
+Deno.test('GET /api/sb/rows sorts rows by query parameters', async () => {
+  const res = await handler(new Request('http://localhost/api/sb/rows?sort=latencyMS&order=desc'));
+  assertEquals(res.status, 200);
+  const data = await res.json();
+  assertEquals(data.sort, 'latencyMS');
+  assertEquals(data.order, 'desc');
+  assertEquals(
+    data.rows.map((row: { latencyMS: number }) => row.latencyMS),
+    [88, 34, 21],
+  );
+});
+
 Deno.test('POST /api/echo returns same JSON', async () => {
   const payload = { hello: 'world' };
   const res = await handler(

--- a/tests/web-app.test.ts
+++ b/tests/web-app.test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from '@std/assert';
+import { nextSortState, readSortState, rowsURL } from '../src/web/app.ts';
+
+Deno.test('readSortState falls back to the default sort for invalid parameters', () => {
+  const state = readSortState(new URLSearchParams('sort=missing&order=sideways'));
+  assertEquals(state, { key: 'service', order: 'asc' });
+});
+
+Deno.test('nextSortState toggles order for the active header', () => {
+  const state = nextSortState({ key: 'service', order: 'asc' }, 'service');
+  assertEquals(state, { key: 'service', order: 'desc' });
+});
+
+Deno.test('nextSortState starts ascending for a different header', () => {
+  const state = nextSortState({ key: 'service', order: 'desc' }, 'latencyMS');
+  assertEquals(state, { key: 'latencyMS', order: 'asc' });
+});
+
+Deno.test('rowsURL passes sort state to /api/sb/rows', () => {
+  assertEquals(
+    rowsURL({ key: 'updatedAt', order: 'desc' }),
+    '/api/sb/rows?sort=updatedAt&order=desc',
+  );
+});


### PR DESCRIPTION
Fixes #2
/claim #2

Summary
- Adds a Rows table with clickable column headers for service, status, latency, and updated time.
- Toggles active headers between ascending and descending order with visible and accessible sort indicators.
- Persists the selected sort in the URL as `sort` and `order` query parameters.
- Passes the same sort state to `/api/sb/rows` and returns sorted rows from the endpoint.
- Adds focused tests for client sort state, URL generation, and server-side row sorting.

Verification
- npx --yes deno@2.7.14 task test
- npx --yes deno@2.7.14 check --config deno.json src/web/app.ts src/server.ts tests/server.test.ts tests/web-app.test.ts
- npx --yes deno@2.7.14 run -A npm:prettier@^3 --check public/index.html public/styles.css src/web/app.ts src/server.ts tests/server.test.ts tests/web-app.test.ts
- npx --yes deno@2.7.14 task build:client
- npx --yes deno@2.7.14 task lint
- npx --yes deno@2.7.14 task knip
- git diff --check
- Browser smoke: initial service sort shows `(asc)`; clicking Latency updates URL to `?sort=latencyMS&order=asc` and sorts 21/34/88 ms; clicking again updates URL to `?sort=latencyMS&order=desc` and sorts 88/34/21 ms with `aria-sort="descending"`.

Bounty Info
Preferred payment method: to be provided privately after acceptance.