### PR TITLE
feat(ui): persist view state in url

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -1,0 +1,15 @@
+# UI State
+
+The browser URL is the source of truth for shareable UI state.
+
+Supported query parameters:
+
+- `table`: selected table name.
+- `offset`: zero-based row offset.
+- `limit`: visible row count.
+- `sort`: active sort column.
+- `desc`: `true` for descending sort, `false` for ascending sort.
+- `filters`: serialized filter text for the current view.
+- `rowId`: selected row identifier.
+
+Opening `/?table=users&offset=50&limit=25&sort=created&desc=true` restores those controls on load. Editing the controls pushes a new history entry, and browser back/forward restores the previous state.

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,41 @@
       </section>
 
       <section>
+        <h2>View State</h2>
+        <form id="viewStateForm" class="state-grid">
+          <label>
+            Table
+            <input id="tableInput" name="table" value="users" />
+          </label>
+          <label>
+            Offset
+            <input id="offsetInput" name="offset" inputmode="numeric" value="0" />
+          </label>
+          <label>
+            Limit
+            <input id="limitInput" name="limit" inputmode="numeric" value="25" />
+          </label>
+          <label>
+            Sort
+            <input id="sortInput" name="sort" value="created" />
+          </label>
+          <label>
+            Desc
+            <input id="descInput" name="desc" type="checkbox" />
+          </label>
+          <label>
+            Filters
+            <input id="filtersInput" name="filters" placeholder="status:active" />
+          </label>
+          <label>
+            Row ID
+            <input id="rowIdInput" name="rowId" />
+          </label>
+        </form>
+        <pre id="viewStateOut"></pre>
+      </section>
+
+      <section>
         <h2>Echo</h2>
         <form id="echoForm">
           <label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -27,6 +27,12 @@ pre {
   background: #0f1115; border: 1px solid #1b1f2a; padding: 0.75rem; border-radius: 6px;
   overflow: auto; max-height: 240px; white-space: pre-wrap; word-break: break-word;
 }
-textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
+input, textarea { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #333; color: inherit; background: transparent; }
+input[type="checkbox"] { width: auto; }
+.state-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.75rem;
+}
 label { display: block; margin-bottom: 0.5rem; color: var(--muted); }
 

--- a/src/web/app.ts
+++ b/src/web/app.ts
@@ -1,4 +1,55 @@
+/// <reference lib="dom" />
+
 type FetchJSONResult = { ok: boolean; status: number; data: unknown };
+export type ViewState = {
+  table: string;
+  offset: number;
+  limit: number;
+  sort: string;
+  desc: boolean;
+  filters: string;
+  rowId: string;
+};
+
+const DEFAULT_VIEW_STATE: ViewState = {
+  table: 'users',
+  offset: 0,
+  limit: 25,
+  sort: 'created',
+  desc: false,
+  filters: '',
+  rowId: '',
+};
+
+function readInteger(value: string | null, fallback: number): number {
+  if (value === null || value.trim() === '') return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+export function parseViewState(params: URLSearchParams): ViewState {
+  return {
+    table: params.get('table') || DEFAULT_VIEW_STATE.table,
+    offset: readInteger(params.get('offset'), DEFAULT_VIEW_STATE.offset),
+    limit: readInteger(params.get('limit'), DEFAULT_VIEW_STATE.limit),
+    sort: params.get('sort') || DEFAULT_VIEW_STATE.sort,
+    desc: params.get('desc') === 'true',
+    filters: params.get('filters') || DEFAULT_VIEW_STATE.filters,
+    rowId: params.get('rowId') || DEFAULT_VIEW_STATE.rowId,
+  };
+}
+
+export function viewStateToSearch(state: ViewState): string {
+  const params = new URLSearchParams();
+  params.set('table', state.table);
+  params.set('offset', String(state.offset));
+  params.set('limit', String(state.limit));
+  params.set('sort', state.sort);
+  params.set('desc', String(state.desc));
+  if (state.filters) params.set('filters', state.filters);
+  if (state.rowId) params.set('rowId', state.rowId);
+  return params.toString();
+}
 
 async function fetchJSON(path: string, options: RequestInit = {}): Promise<FetchJSONResult> {
   const res = await fetch(path, options);
@@ -22,7 +73,39 @@ function byId<T extends HTMLElement>(id: string): T {
   return el as T;
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function viewStateFromForm(form: HTMLFormElement): ViewState {
+  const data = new FormData(form);
+  return {
+    table: String(data.get('table') || DEFAULT_VIEW_STATE.table),
+    offset: readInteger(String(data.get('offset') || ''), DEFAULT_VIEW_STATE.offset),
+    limit: readInteger(String(data.get('limit') || ''), DEFAULT_VIEW_STATE.limit),
+    sort: String(data.get('sort') || DEFAULT_VIEW_STATE.sort),
+    desc: data.get('desc') === 'on',
+    filters: String(data.get('filters') || ''),
+    rowId: String(data.get('rowId') || ''),
+  };
+}
+
+function applyViewState(form: HTMLFormElement, output: HTMLElement, state: ViewState) {
+  byId<HTMLInputElement>('tableInput').value = state.table;
+  byId<HTMLInputElement>('offsetInput').value = String(state.offset);
+  byId<HTMLInputElement>('limitInput').value = String(state.limit);
+  byId<HTMLInputElement>('sortInput').value = state.sort;
+  byId<HTMLInputElement>('descInput').checked = state.desc;
+  byId<HTMLInputElement>('filtersInput').value = state.filters;
+  byId<HTMLInputElement>('rowIdInput').value = state.rowId;
+  show(output, state);
+  form.dataset.currentState = JSON.stringify(state);
+}
+
+function updateURL(state: ViewState, mode: 'push' | 'replace') {
+  const url = new URL(window.location.href);
+  url.search = viewStateToSearch(state);
+  const method = mode === 'push' ? 'pushState' : 'replaceState';
+  window.history[method](state, '', url);
+}
+
+export function initApp() {
   const healthBtn = byId<HTMLButtonElement>('checkHealth');
   const healthOut = byId<HTMLPreElement>('healthOut');
   const timeBtn = byId<HTMLButtonElement>('getTime');
@@ -30,6 +113,12 @@ window.addEventListener('DOMContentLoaded', () => {
   const echoForm = byId<HTMLFormElement>('echoForm');
   const echoInput = byId<HTMLTextAreaElement>('echoInput');
   const echoOut = byId<HTMLPreElement>('echoOut');
+  const viewStateForm = byId<HTMLFormElement>('viewStateForm');
+  const viewStateOut = byId<HTMLPreElement>('viewStateOut');
+  const initialState = parseViewState(new URLSearchParams(window.location.search));
+
+  applyViewState(viewStateForm, viewStateOut, initialState);
+  updateURL(initialState, 'replace');
 
   healthBtn.addEventListener('click', async () => {
     const res = await fetchJSON('/api/health');
@@ -41,7 +130,7 @@ window.addEventListener('DOMContentLoaded', () => {
     show(timeOut, res);
   });
 
-  echoForm.addEventListener('submit', async (e) => {
+  echoForm.addEventListener('submit', async (e: SubmitEvent) => {
     e.preventDefault();
     const bodyText = echoInput.value || '{}';
     try {
@@ -57,4 +146,19 @@ window.addEventListener('DOMContentLoaded', () => {
     });
     show(echoOut, res);
   });
-});
+
+  viewStateForm.addEventListener('input', () => {
+    const nextState = viewStateFromForm(viewStateForm);
+    applyViewState(viewStateForm, viewStateOut, nextState);
+    updateURL(nextState, 'push');
+  });
+
+  window.addEventListener('popstate', () => {
+    const state = parseViewState(new URLSearchParams(window.location.search));
+    applyViewState(viewStateForm, viewStateOut, state);
+  });
+}
+
+if (typeof document !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', initApp);
+}

--- a/tests/web-app.test.ts
+++ b/tests/web-app.test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from '@std/assert';
+import { parseViewState, viewStateToSearch } from '../src/web/app.ts';
+
+Deno.test('parseViewState reads deep-link parameters', () => {
+  const state = parseViewState(
+    new URLSearchParams(
+      'table=users&offset=50&limit=25&sort=created&desc=true&filters=status:active&rowId=u_1',
+    ),
+  );
+
+  assertEquals(state, {
+    table: 'users',
+    offset: 50,
+    limit: 25,
+    sort: 'created',
+    desc: true,
+    filters: 'status:active',
+    rowId: 'u_1',
+  });
+});
+
+Deno.test('parseViewState falls back for missing and invalid numeric params', () => {
+  const state = parseViewState(new URLSearchParams('offset=-1&limit=abc'));
+
+  assertEquals(state.offset, 0);
+  assertEquals(state.limit, 25);
+  assertEquals(state.table, 'users');
+  assertEquals(state.sort, 'created');
+});
+
+Deno.test('viewStateToSearch writes stable shareable parameters', () => {
+  const query = viewStateToSearch({
+    table: 'orders',
+    offset: 10,
+    limit: 50,
+    sort: 'total',
+    desc: false,
+    filters: '',
+    rowId: 'ord_9',
+  });
+
+  assertEquals(query, 'table=orders&offset=10&limit=50&sort=total&desc=false&rowId=ord_9');
+});


### PR DESCRIPTION
Fixes #1
/claim #1

Summary
- Adds View State controls for table, offset, limit, sort, desc, filters, and rowId.
- Parses those values from the URL on load and normalizes invalid numeric values.
- Writes control changes back to the URL with pushState so the view is shareable.
- Handles popstate so browser back/forward restores prior view state.
- Documents the supported UI query parameters in docs/UI.md.
- Adds focused tests for deep-link parsing and stable URL serialization.

Verification
- npx --yes deno@2.7.14 task test
- npx --yes deno@2.7.14 check --config deno.json src/web/app.ts tests/web-app.test.ts
- npx --yes deno@2.7.14 run -A npm:prettier@^3 --check public/index.html public/styles.css src/web/app.ts tests/web-app.test.ts docs/UI.md
- npx --yes deno@2.7.14 task build:client
- npx --yes deno@2.7.14 task lint
- npx --yes deno@2.7.14 task knip
- git diff --check
- Browser smoke: /?table=users&offset=50&limit=25&sort=created&desc=true restored the controls; editing offset updated the URL; browser Back restored offset=50.

Bounty Info
Preferred payment method: to be provided privately after acceptance.
